### PR TITLE
refactor: use forked arweave-wallet-kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@arweave-wallet-kit-beta/arconnect-strategy": "^0.0.1-beta.5",
+    "@arweave-wallet-kit-beta/browser-wallet-strategy": "^0.0.1-beta.4",
+    "@arweave-wallet-kit-beta/core": "^0.0.1-beta.4",
+    "@arweave-wallet-kit-beta/react": "^0.0.1-beta.4",
     "@headlessui/react": "^1.7.16",
     "@hookform/resolvers": "^3.2.0",
     "@isomorphic-git/lightning-fs": "^4.6.0",
@@ -21,7 +25,6 @@
     "@uiw/react-codemirror": "^4.21.11",
     "@uiw/react-md-editor": "^3.23.5",
     "arweave": "^1.14.4",
-    "arweave-wallet-kit": "^1.0.1",
     "clsx": "^2.0.0",
     "date-fns": "^2.30.0",
     "dexie": "^3.2.4",

--- a/src/components/Navbar/UserProfileButton.tsx
+++ b/src/components/Navbar/UserProfileButton.tsx
@@ -1,5 +1,5 @@
+import { useActiveAddress, useConnection, useStrategy } from '@arweave-wallet-kit-beta/react'
 import { Menu, Transition } from '@headlessui/react'
-import { useActiveAddress, useConnection, useStrategy } from 'arweave-wallet-kit'
 import { Fragment, useEffect, useRef } from 'react'
 import { AiOutlineProfile } from 'react-icons/ai'
 import { BiLogOutCircle } from 'react-icons/bi'

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,8 @@
 import './index.css'
 
-import { ArweaveWalletKit } from 'arweave-wallet-kit'
+import ArConnectStrategy from '@arweave-wallet-kit-beta/arconnect-strategy'
+import BrowserWalletStrategy from '@arweave-wallet-kit-beta/browser-wallet-strategy'
+import { ArweaveWalletKit } from '@arweave-wallet-kit-beta/react'
 import ReactDOM from 'react-dom/client'
 
 import App from './App.tsx'
@@ -11,6 +13,7 @@ initializeGoogleAnalytics()
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <ArweaveWalletKit
     config={{
+      strategies: [new ArConnectStrategy(), new BrowserWalletStrategy()],
       permissions: ['ACCESS_ADDRESS', 'SIGN_TRANSACTION', 'ACCESS_PUBLIC_KEY', 'SIGNATURE', 'DISPATCH'],
       ensurePermissions: true
     }}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,4 +1,4 @@
-import { useConnection } from 'arweave-wallet-kit'
+import { useConnection } from '@arweave-wallet-kit-beta/react'
 import React from 'react'
 
 import { Button } from '@/components/common/buttons'

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,10 +136,33 @@
     axios "0.27.2"
     got "^11.0.0"
 
-"@auth0/auth0-spa-js@^2.0.4":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.1.tgz#4cc798ce7c20fcefbe362bf5e5b6ba2cb5c466ab"
-  integrity sha512-21qEf5Bjouy76CWd1gQgf/tT6iD513YFYaK0+3OF1nbwLtPFpxm5Ln94M7SCVFKfe5jbchWuEcIb1HLer3r6RA==
+"@arweave-wallet-kit-beta/arconnect-strategy@^0.0.1-beta.5":
+  version "0.0.1-beta.5"
+  resolved "https://registry.yarnpkg.com/@arweave-wallet-kit-beta/arconnect-strategy/-/arconnect-strategy-0.0.1-beta.5.tgz#fa1a28a7d46f9d441dc5cfdc8bf3b24ab870053e"
+  integrity sha512-7HFqy+FlUmBoIfadaap5khUC9AKnFxro8Q4LbFW07gMnZCYw7myiBHzBOSziJ+F4k0GwTg3YhW/DExRxwdb6fw==
+
+"@arweave-wallet-kit-beta/browser-wallet-strategy@^0.0.1-beta.4":
+  version "0.0.1-beta.4"
+  resolved "https://registry.yarnpkg.com/@arweave-wallet-kit-beta/browser-wallet-strategy/-/browser-wallet-strategy-0.0.1-beta.4.tgz#da6122a61db08d596b4bb5357c8bf0262382f395"
+  integrity sha512-SG8EyD0Hr/hBVBwcA7bUlTHJfyeEx3g2oJb8X2HdMaCzKprn+BFpbnEhexpReWcMbqsWhG66S6zS73ny06AB3A==
+
+"@arweave-wallet-kit-beta/core@^0.0.1-beta.4":
+  version "0.0.1-beta.4"
+  resolved "https://registry.yarnpkg.com/@arweave-wallet-kit-beta/core/-/core-0.0.1-beta.4.tgz#66191b59473a0d03c0ab689c01c4fe5642ee32ee"
+  integrity sha512-V/ni0CdAX8Mfp/Ta7yhhmGbklXNL83RPBn2q5tNOLJJRWyBl80TYQeLV/DuHtPz9zv9Fosjd5sc1uF5ijXqyVg==
+
+"@arweave-wallet-kit-beta/react@^0.0.1-beta.4":
+  version "0.0.1-beta.4"
+  resolved "https://registry.yarnpkg.com/@arweave-wallet-kit-beta/react/-/react-0.0.1-beta.4.tgz#72d1c7c1a4d5b09ef4945da76d49bc4f84c8de3d"
+  integrity sha512-uZwbKwBlszcRJbcXG7gXGoBTEbxLhEUerUx7F5MxiKsbgicyW0fLU0dOJDMl7M7Yc0JdPHgz5pydeLDVRiwlJg==
+  dependencies:
+    "@callstack/react-theme-provider" "^3.0.8"
+    "@iconicicons/react" "^1.5.1"
+    "@linaria/babel-preset" "^4.4.5"
+    "@linaria/core" "^4.2.10"
+    "@linaria/react" "^4.3.8"
+    framer-motion "^8.1.9"
+    react-helmet "^6.1.0"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.22.5":
   version "7.22.5"
@@ -3935,30 +3958,6 @@ arweave-stream-tx@^1.1.0:
   dependencies:
     exponential-backoff "^3.1.0"
 
-arweave-wallet-connector@^0.0.31:
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/arweave-wallet-connector/-/arweave-wallet-connector-0.0.31.tgz#34ebd825c2ea9fb6cebe15e71cfdddb505beccb8"
-  integrity sha512-FPjyklATFZmXdcpmXRO6iX5OOc0TgSb2SX0omXuKbhzqiJ0l99d6jzuPy9teDMmm9wx6KSDiTQaOTnVIuPjkgQ==
-  dependencies:
-    mitt "^3.0.0"
-    typescript-is "^0.19.0"
-
-arweave-wallet-kit@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/arweave-wallet-kit/-/arweave-wallet-kit-1.0.1.tgz#aa1083b6c903a5b463fdef0b83f74b4a0860115a"
-  integrity sha512-EXspFZiGEHijYYKdBZD1bQmcXYAHTDTwJx+Tzsq0Yb/bsMMlJt4AknwBqoEmgUuxOY/WWk+X2gKDcj5GFUZ92g==
-  dependencies:
-    "@callstack/react-theme-provider" "^3.0.8"
-    "@iconicicons/react" "^1.5.1"
-    "@linaria/babel-preset" "^4.4.5"
-    "@linaria/core" "^4.2.10"
-    "@linaria/react" "^4.3.8"
-    arweave "^1.12.2"
-    arweave-wallet-connector "^0.0.31"
-    framer-motion "^8.1.9"
-    othent "^1.0.634"
-    react-helmet "^6.1.0"
-
 arweave@1.13.7:
   version "1.13.7"
   resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.13.7.tgz#cda8534c833baec372a7052c61f53b4e39a886d7"
@@ -3981,7 +3980,7 @@ arweave@=1.11.8:
     bignumber.js "^9.0.2"
     util "^0.12.4"
 
-arweave@^1.10.13, arweave@^1.10.5, arweave@^1.11.4, arweave@^1.12.2, arweave@^1.13.1, arweave@^1.13.7, arweave@^1.14.4:
+arweave@^1.10.13, arweave@^1.10.5, arweave@^1.11.4, arweave@^1.13.1, arweave@^1.13.7, arweave@^1.14.4:
   version "1.14.4"
   resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.14.4.tgz#5ba22136aa0e7fd9495258a3931fb770c9d6bf21"
   integrity sha512-tmqU9fug8XAmFETYwgUhLaD3WKav5DaM4p1vgJpEj/Px2ORPPMikwnSySlFymmL2qgRh2ZBcZsg11+RXPPGLsA==
@@ -3991,7 +3990,7 @@ arweave@^1.10.13, arweave@^1.10.5, arweave@^1.11.4, arweave@^1.12.2, arweave@^1.
     base64-js "^1.5.1"
     bignumber.js "^9.0.2"
 
-asn1.js@5.4.1, asn1.js@^5.2.0, asn1.js@^5.3.0, asn1.js@^5.4.1:
+asn1.js@5.4.1, asn1.js@^5.2.0, asn1.js@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
   integrity sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==
@@ -4080,15 +4079,6 @@ axios@^0.21.3:
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
-
-axios@^1.3.4:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
-  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
-  dependencies:
-    follow-redirects "^1.15.0"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
 
 babel-merge@^3.0.0:
   version "3.0.0"
@@ -4939,11 +4929,6 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
-
-crypto-js@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
-  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
 css-selector-parser@^1.0.0:
   version "1.4.1"
@@ -5988,7 +5973,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-follow-redirects@^1.14.0, follow-redirects@^1.14.9, follow-redirects@^1.15.0:
+follow-redirects@^1.14.0, follow-redirects@^1.14.9:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -7160,11 +7145,6 @@ json5@^2.2.2:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsrsasign@^10.8.6:
-  version "10.8.6"
-  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-10.8.6.tgz#ebf7f3c812c6517af84f0d8a10115e0dbfabe145"
-  integrity sha512-bQmbVtsfbgaKBTWCKiDCPlUPbdlRIK/FzSwT3BzIgZl/cU6TqXu6pZJsCI/dJVrZ9Gir5GC4woqw9shH/v7MBw==
-
 jszip@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
@@ -7184,20 +7164,6 @@ just-once@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/just-once/-/just-once-1.1.0.tgz#fe81a185ebaeeb0947a7e705bf01cb6808db0ad8"
   integrity sha512-+rZVpl+6VyTilK7vB/svlMPil4pxqIJZkbnN7DKZTOzyXfun6ZiFeq2Pk4EtCEHZ0VU4EkdFzG8ZK5F3PErcDw==
-
-jwk-to-pem@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/jwk-to-pem/-/jwk-to-pem-2.0.5.tgz#151310bcfbcf731adc5ad9f379cbc8b395742906"
-  integrity sha512-L90jwellhO8jRKYwbssU9ifaMVqajzj3fpRjDKcsDzrslU9syRbFqfkXtT4B89HYAap+xsxNcxgBSB09ig+a7A==
-  dependencies:
-    asn1.js "^5.3.0"
-    elliptic "^6.5.4"
-    safe-buffer "^5.0.1"
-
-jwt-decode@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
-  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
 
 keccak@^3.0.2:
   version "3.0.3"
@@ -8232,11 +8198,6 @@ minizlib@^2.0.0, minizlib@^2.1.1:
     minipass "^3.0.0"
     yallist "^4.0.0"
 
-mitt@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
-  integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
-
 mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
@@ -8322,11 +8283,6 @@ negotiator@0.6.3, negotiator@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
-
-nested-error-stacks@^2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.1.tgz#26c8a3cee6cc05fbcf1e333cd2fc3e003326c0b5"
-  integrity sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==
 
 next-tick@1, next-tick@^1.1.0:
   version "1.1.0"
@@ -8623,20 +8579,6 @@ os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
-
-othent@^1.0.634:
-  version "1.0.639"
-  resolved "https://registry.yarnpkg.com/othent/-/othent-1.0.639.tgz#dc55ad10889daf29de73429b93ceecea6bf64d23"
-  integrity sha512-6kHzDDJG2j/DkeaFpuTSLBRRg8RZ5cn9txt4/Kd9kmU1VTr6iAKr+CgIxao9f8cc42isVHcrtqkDm2E3YN09IQ==
-  dependencies:
-    "@auth0/auth0-spa-js" "^2.0.4"
-    axios "^1.3.4"
-    crypto-js "^4.1.1"
-    debug "^4.3.4"
-    jsrsasign "^10.8.6"
-    jwk-to-pem "^2.0.5"
-    jwt-decode "^3.1.2"
-    supports-color "^8.1.1"
 
 p-cancelable@^2.0.0:
   version "2.1.1"
@@ -8954,11 +8896,6 @@ property-information@^6.0.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.3.0.tgz#ba4a06ec6b4e1e90577df9931286953cdf4282c3"
   integrity sha512-gVNZ74nqhRMiIUYWGQdosYetaKc83x8oT41a0LlV3AAFCAZwCpg4vmGkq8t34+cUhp3cnM4XDiU/7xlgK7HGrg==
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 ps-tree@^1.2.0:
   version "1.2.0"
@@ -9371,11 +9308,6 @@ redent@^4.0.0:
   dependencies:
     indent-string "^5.0.0"
     strip-indent "^4.0.0"
-
-reflect-metadata@>=0.1.12:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
-  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
 
 refractor@^4.8.0:
   version "4.8.1"
@@ -10219,13 +10151,6 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.1.1:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
-  dependencies:
-    has-flag "^4.0.0"
-
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
@@ -10452,11 +10377,6 @@ tsconfig-paths@^3.14.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
 tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
@@ -10466,13 +10386,6 @@ tsscmp@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
   integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
-
-tsutils@^3.17.1:
-  version "3.21.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
-  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
-  dependencies:
-    tslib "^1.8.1"
 
 tty-browserify@0.0.1:
   version "0.0.1"
@@ -10567,16 +10480,6 @@ typed-array-length@^1.0.4:
     call-bind "^1.0.2"
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
-
-typescript-is@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/typescript-is/-/typescript-is-0.19.0.tgz#5e42ad64f899d5eb169bc2fa692331638d02fa25"
-  integrity sha512-SAJEx2cxbQZhfOjDEjPnQJt1qRS1M3wrKbUwvsywVHWGbMgM1dcIf9gPWNDS1/dgTa/7Iexk2mmAHHsP9MeCsA==
-  dependencies:
-    nested-error-stacks "^2"
-    tsutils "^3.17.1"
-  optionalDependencies:
-    reflect-metadata ">=0.1.12"
 
 typescript@^5.0.2:
   version "5.1.6"


### PR DESCRIPTION
## Summary

Forked and redeployed
    - `@arweave-wallet-kit/arconnect-strategy`
    - `@arweave-wallet-kit/browser-wallet-strategy`,
    - `@arweave-wallet-kit/react`
   
Under namespace `@'@arweave-wallet-kit-beta` temporarily to use latest features of the project.