### PR TITLE
feat: Add PL repo as default to sidebar

### DIFF
--- a/.github/workflows/pl-sync.yml
+++ b/.github/workflows/pl-sync.yml
@@ -15,7 +15,7 @@ jobs:
       - name: 'Checkout all branches'
         run: |
           default_branch=$(git branch | grep '*' | sed 's/\* //')
-          for abranch in $(git branch -a | grep -v HEAD | grep remotes | sed "s/remotes/origin/g"); do git checkout $abranch ; done
+          for abranch in $(git branch -a | grep -v HEAD | grep remotes | sed "s/remotes\/origin\//origin\//g"); do git checkout $abranch ; done
           git checkout $default_branch
           git branch -a
       - name: 'Setup node 18'

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,2 +1,3 @@
 export const CONTRACT_TX_ID = 'w5ZU15Y2cLzZlu3jewauIlnzbKw-OAxbN9G5TbuuiDQ'
 export const VITE_GA_TRACKING_ID = "G-L433HSR0D0"
+export const PL_REPO_ID = '6ace6247-d267-463d-b5bd-7e50d98c3693'

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,9 +1,11 @@
 import { useConnection } from '@arweave-wallet-kit-beta/react'
 import React from 'react'
 import toast from 'react-hot-toast'
+import { useNavigate } from 'react-router-dom'
 
 import { Button } from '@/components/common/buttons'
 import CreateProfileModal from '@/components/CreateProfileModal/CreateProfileModal'
+import { PL_REPO_ID } from '@/helpers/constants'
 import { trackGoogleAnalyticsEvent, trackGoogleAnalyticsPageView } from '@/helpers/google-analytics'
 import { useGlobalStore } from '@/stores/globalStore'
 
@@ -18,6 +20,7 @@ export default function Home() {
   const [isOpen, setIsOpen] = React.useState(false)
   const [isCreateProfileModalOpen, setIsCreateProfileModalOpen] = React.useState(false)
   const { connect } = useConnection()
+  const navigate = useNavigate()
 
   React.useEffect(() => {
     trackGoogleAnalyticsPageView('pageview', '/', 'Home Page Visit')
@@ -52,6 +55,10 @@ export default function Home() {
     window.open(NPM_URL, '_blank')
   }
 
+  function handleExploreClick() {
+    navigate(`/repository/${PL_REPO_ID}`)
+  }
+
   return (
     <div className="h-full flex flex-1">
       <Sidebar repos={userRepos} isLoading={fetchUserReposStatus === 'PENDING'} />
@@ -66,7 +73,7 @@ export default function Home() {
               Game changing decentralized <br />
               code collaboration
             </h1>
-            <Button className="font-medium" variant="primary-solid">
+            <Button onClick={handleExploreClick} className="font-medium" variant="primary-solid">
               Explore
             </Button>
           </div>

--- a/src/pages/home/hooks/useFetchUserRepos.ts
+++ b/src/pages/home/hooks/useFetchUserRepos.ts
@@ -1,10 +1,11 @@
 import { useState } from 'react'
 import { InjectedArweaveSigner } from 'warp-contracts-plugin-signature'
 
-import { CONTRACT_TX_ID } from '@/helpers/constants'
+import { CONTRACT_TX_ID, PL_REPO_ID } from '@/helpers/constants'
 import getWarpContract from '@/helpers/getWrapContract'
 import { withAsync } from '@/helpers/withAsync'
 import { useGlobalStore } from '@/stores/globalStore'
+import { getRepositoryMetaFromContract } from '@/stores/repository-core/actions'
 
 export function useFetchUserRepos() {
   const [address, userRepos, setUserRepos] = useGlobalStore((state) => [
@@ -30,6 +31,8 @@ export function useFetchUserRepos() {
       })
     )
 
+    const { response: PLRepoResponse } = await withAsync(() => getRepositoryMetaFromContract(PL_REPO_ID))
+
     const { response: collabResponse, error: collabError } = await withAsync(() =>
       contract.viewState({
         function: 'getRepositoriesByContributor',
@@ -42,7 +45,9 @@ export function useFetchUserRepos() {
     if (ownerReposError || collabError) {
       setFetchUserReposStatus('ERROR')
     } else if (ownerReposResponse && collabResponse) {
-      setUserRepos([...ownerReposResponse.result, ...collabResponse.result])
+      const PLRepo = PLRepoResponse ? [PLRepoResponse.result] : []
+
+      setUserRepos([...PLRepo, ...ownerReposResponse.result, ...collabResponse.result])
       setFetchUserReposStatus('SUCCESS')
     }
   }


### PR DESCRIPTION
## Summary 
Add PL repo to sidebar by default and redirect to PL repo when clicked on explore.

Also there was an error using PL Sync workflow file
```bash
default_branch=$(git branch | grep '*' | sed 's/\* //')
  for abranch in $(git branch -a | grep -v HEAD | grep remotes | sed "s/remotes/origin/g"); do git checkout $abranch ; done
  git checkout $default_branch
  git branch -a
  shell: /usr/bin/bash -e ***0***
error: pathspec 'origin/origin/development' did not match any file(s) known to git
Error: Process completed with exit code 1.
```

The problem seems to be in the line where we're iterating through remote branches and attempting to checkout them:

`for abranch in $(git branch -a | grep -v HEAD | grep remotes | sed "s/remotes/origin/g"); do git checkout $abranch ; done`

To fix this, we should modify the sed command to replace "remotes/origin/" with "origin/" instead of replacing "remotes/" with "origin."

With the change proposed in this commit, the script should correctly handle remote branches without introducing the "origin/origin" issue.