### PR TITLE
fix: Introduce route for repo tabs, fixing the pull & issue back button problem.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ function App() {
         <Routes>
           <Route index path="/" element={<Home />} />
           <Route index path="/user/:id" element={<Profile />} />
-          <Route path="/repository/:id" element={<Repository />} />
+          <Route path="/repository/:id/:tabName?" element={<Repository />} />
           <Route path="/repository/:id/pull/new" element={<NewPullRequest />} />
           <Route path="/repository/:id/pull/:pullId" element={<ReadPullRequest />} />
           <Route path="/repository/:id/issue/new" element={<CreateIssuePage />} />

--- a/src/pages/issue/read/components/IssueHeader.tsx
+++ b/src/pages/issue/read/components/IssueHeader.tsx
@@ -33,7 +33,7 @@ export default function IssueHeader({ issue }: { issue: Issue }) {
   const StatusComponent = statusMap[issue.status]
 
   function goBack() {
-    navigate(-1)
+    navigate(`/repository/${issue.repoId}/issues`)
   }
 
   return (

--- a/src/pages/pull/read/components/PullRequestHeader.tsx
+++ b/src/pages/pull/read/components/PullRequestHeader.tsx
@@ -30,7 +30,7 @@ export default function PullRequestHeader({ PR }: { PR: PullRequest }) {
   const navigate = useNavigate()
 
   function goBack() {
-    navigate(-1)
+    navigate(`/repository/${PR.repoId}/pulls`)
   }
 
   return (

--- a/src/pages/repository/Repository.tsx
+++ b/src/pages/repository/Repository.tsx
@@ -40,14 +40,8 @@ export default function Repository() {
     const tab = rootTabConfig[idx]
     const repo = selectedRepo.repo
 
-    const targetPath =
-      tab.title !== 'Code'
-        ? tab.title === 'Pull Requests'
-          ? `/repository/${id}/pulls`
-          : `/repository/${id}/${tab.title.toLowerCase()}`
-        : `/repository/${id}`
+    const targetPath = tab.getPath(id!)
 
-    // window.history.pushState(null, '', `/#${targetPath}`)
     navigate(targetPath)
 
     if (tab && repo) {

--- a/src/pages/repository/components/tabs/settings-tab/Contributors.tsx
+++ b/src/pages/repository/components/tabs/settings-tab/Contributors.tsx
@@ -25,6 +25,7 @@ export default function Contributors() {
   const {
     register,
     handleSubmit,
+    resetField,
     formState: { errors }
   } = useForm({
     resolver: yupResolver(addressSchema)
@@ -39,6 +40,7 @@ export default function Contributors() {
         toast.error('You already have permissions to this repo')
       } else {
         await addContributor(data.address)
+        resetField('address')
         toast.success('Successfully added a contributor')
       }
     }

--- a/src/pages/repository/config/rootTabConfig.ts
+++ b/src/pages/repository/config/rootTabConfig.ts
@@ -12,26 +12,31 @@ export const rootTabConfig = [
   {
     title: 'Code',
     Component: CodeTab,
-    Icon: BiCodeAlt
+    Icon: BiCodeAlt,
+    getPath: (id: string) => `/repository/${id}`
   },
   {
     title: 'Issues',
     Component: IssuesTab,
-    Icon: VscIssues
+    Icon: VscIssues,
+    getPath: (id: string) => `/repository/${id}/issues`
   },
   {
     title: 'Commits',
     Component: CommitsTab,
-    Icon: FiGitCommit
+    Icon: FiGitCommit,
+    getPath: (id: string) => `/repository/${id}/commits`
   },
   {
     title: 'Pull Requests',
     Component: PullRequestsTab,
-    Icon: FiGitPullRequest
+    Icon: FiGitPullRequest,
+    getPath: (id: string) => `/repository/${id}/pulls`
   },
   {
     title: 'Settings',
     Component: SettingsTab,
-    Icon: FiSettings
+    Icon: FiSettings,
+    getPath: (id: string) => `/repository/${id}/settings`
   }
 ]


### PR DESCRIPTION
## Summary
- This PR introduces route to repository tabs (Code, Issues, Pull Requests etc) such that each tab can be persisted even on refresh too. 
- It solves the issue of going back from a issue or PR back to Code tab instead of going back to Issues or Pull Requests tab. 
- After creating a new PR, pressing the back button now navigates to the Issues or Pull Requests tab, improving user flow compared to returning to the creation form.
- Additionally, it also resolves issue of clearing the contributor address text input once successfully added in the Repository Settings.

## Screenshots
- The URL for the "Issues Tab" now appears as follows, and it can be refreshed to maintain the same Issues tab.

![image](https://github.com/labscommunity/protocol-land/assets/11836100/74595159-4803-4f3e-85f6-1e59acfc0a4c)

- Takes back to Issues tab when clicked. Similar for Pull requests too.

![image](https://github.com/labscommunity/protocol-land/assets/11836100/256ea50d-59cd-4d91-aa18-f1d46dca5b30) 

- Contributor address text input is cleared on successful addition.

![image](https://github.com/labscommunity/protocol-land/assets/11836100/b668438e-f329-41d9-b832-78391bf1ed35)

