### PR TITLE
fix: Update PR UI with clickable links for branches and PR creator

### DIFF
--- a/src/components/IssuePr/Description.tsx
+++ b/src/components/IssuePr/Description.tsx
@@ -118,7 +118,10 @@ export default function Description({ issueOrPr }: { issueOrPr: Issue | PullRequ
             </div>
           </div>
         ) : (
-          <MDEditor.Markdown className="p-2" source={issueOrPr?.description ?? ''} />
+          <MDEditor.Markdown
+            className="p-2"
+            source={issueOrPr?.description || '<i style="color: #656D76;">No description provided.</i>'}
+          />
         )}
       </div>
     </div>

--- a/src/pages/issue/create/index.tsx
+++ b/src/pages/issue/create/index.tsx
@@ -113,7 +113,7 @@ export default function CreateIssuePage() {
         <div className="flex justify-center py-4">
           <Button
             isLoading={isSubmitting}
-            disabled={isSubmitting || value.length === 0}
+            disabled={isSubmitting}
             onClick={handleSubmit(createNewIssue)}
             variant="primary-solid"
           >

--- a/src/pages/pull/create/components/RepoDropdown.tsx
+++ b/src/pages/pull/create/components/RepoDropdown.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 export default function RepoDropdown({ selectedItem, setSelectedItem, items, label, disabled = false }: Props) {
   function repoObjToRepoName(repo: Repo) {
-    return `${shortenAddress(repo.owner, 5)}/${repo.name}`
+    return `${shortenAddress(repo.owner || '', 5)}/${repo.name}`
   }
 
   return (
@@ -48,7 +48,9 @@ export default function RepoDropdown({ selectedItem, setSelectedItem, items, lab
               >
                 {({ selected }) => (
                   <>
-                    <span className={`block truncate ${selected ? 'font-medium' : 'font-normal'}`}>{repoObjToRepoName(item)}</span>
+                    <span className={`block truncate ${selected ? 'font-medium' : 'font-normal'}`}>
+                      {repoObjToRepoName(item)}
+                    </span>
                   </>
                 )}
               </Listbox.Option>

--- a/src/pages/pull/create/components/RepoDropdown.tsx
+++ b/src/pages/pull/create/components/RepoDropdown.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 export default function RepoDropdown({ selectedItem, setSelectedItem, items, label, disabled = false }: Props) {
   function repoObjToRepoName(repo: Repo) {
-    return `${shortenAddress(repo.owner || '', 5)}/${repo.name}`
+    return `${shortenAddress(repo?.owner || '', 5)}/${repo.name}`
   }
 
   return (

--- a/src/pages/pull/create/index.tsx
+++ b/src/pages/pull/create/index.tsx
@@ -105,8 +105,8 @@ export default function CreatePullRequest() {
         }
       }
 
-      if (selectedRepo.repo) {
-        const openPR = selectedRepo.repo.pullRequests.find(
+      if (baseRepo) {
+        const openPR = baseRepo.pullRequests.find(
           (pr) =>
             pr.baseBranch === baseBranch &&
             pr.compareBranch === compareBranch &&

--- a/src/pages/pull/read/components/PullRequestHeader.tsx
+++ b/src/pages/pull/read/components/PullRequestHeader.tsx
@@ -69,8 +69,8 @@ export default function PullRequestHeader({
             className="font-medium cursor-pointer hover:underline hover:text-primary-700"
             onClick={() => gotoUser(PR?.author)}
           >
-            {PR?.author && shortenAddress(PR?.author)}{' '}
-          </span>
+            {PR?.author && shortenAddress(PR?.author)}
+          </span>{' '}
           wants to merge{' '}
           <span
             className="text-primary-600 bg-primary-200 px-1 cursor-pointer"

--- a/src/pages/pull/read/components/PullRequestHeader.tsx
+++ b/src/pages/pull/read/components/PullRequestHeader.tsx
@@ -30,11 +30,11 @@ const statusMap = {
 export default function PullRequestHeader({
   PR,
   repo,
-  forkRepo
+  compareRepoOwner
 }: {
   PR: PullRequest
   repo: Repo
-  forkRepo: Repo | null
+  compareRepoOwner: string
 }) {
   const StatusComponent = statusMap[PR.status]
   const navigate = useNavigate()
@@ -76,7 +76,7 @@ export default function PullRequestHeader({
             className="text-primary-600 bg-primary-200 px-1 cursor-pointer"
             onClick={() => gotoBranch(PR.compareRepo.repoId, PR?.compareBranch)}
           >
-            {isMergeInSameRepo ? PR?.compareBranch : `${shortenAddress(forkRepo?.owner ?? '')}:${PR?.compareBranch}`}
+            {isMergeInSameRepo ? PR?.compareBranch : `${shortenAddress(compareRepoOwner)}:${PR?.compareBranch}`}
           </span>{' '}
           into{' '}
           <span

--- a/src/pages/pull/read/components/PullRequestHeader.tsx
+++ b/src/pages/pull/read/components/PullRequestHeader.tsx
@@ -6,7 +6,8 @@ import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/common/buttons'
 import PrTitle from '@/components/IssuePr/Title'
 import { shortenAddress } from '@/helpers/shortenAddress'
-import { PullRequest, PullRequestStatus } from '@/types/repository'
+import { rootTabConfig } from '@/pages/repository/config/rootTabConfig'
+import { PullRequest, PullRequestStatus, Repo } from '@/types/repository'
 
 const statusMap = {
   OPEN: ({ status }: { status: PullRequestStatus }) => (
@@ -26,12 +27,31 @@ const statusMap = {
   )
 }
 
-export default function PullRequestHeader({ PR }: { PR: PullRequest }) {
+export default function PullRequestHeader({
+  PR,
+  repo,
+  forkRepo
+}: {
+  PR: PullRequest
+  repo: Repo
+  forkRepo: Repo | null
+}) {
   const StatusComponent = statusMap[PR.status]
   const navigate = useNavigate()
+  const isMergeInSameRepo = PR.baseRepo.repoId === PR.compareRepo.repoId
 
   function goBack() {
     navigate(`/repository/${PR.repoId}/pulls`)
+  }
+
+  function gotoBranch(id: string, branchName: string) {
+    navigate(rootTabConfig[0].getPath(id, branchName))
+  }
+
+  function gotoUser(userAddress: string) {
+    if (userAddress) {
+      navigate(`/user/${userAddress}`)
+    }
   }
 
   return (
@@ -45,9 +65,26 @@ export default function PullRequestHeader({ PR }: { PR: PullRequest }) {
       <div className="flex items-center gap-4">
         {PR && <StatusComponent status={PR!.status} />}
         <div className="text-gray-900 text-lg">
-          <span className="font-medium">{PR?.author && shortenAddress(PR?.author)} </span>
-          wants to merge <span className="text-primary-600 bg-primary-200 px-1">{PR?.compareBranch}</span> into{' '}
-          <span className="text-primary-600 bg-primary-200 px-1">{PR?.baseBranch}</span>
+          <span
+            className="font-medium cursor-pointer hover:underline hover:text-primary-700"
+            onClick={() => gotoUser(PR?.author)}
+          >
+            {PR?.author && shortenAddress(PR?.author)}{' '}
+          </span>
+          wants to merge{' '}
+          <span
+            className="text-primary-600 bg-primary-200 px-1 cursor-pointer"
+            onClick={() => gotoBranch(PR.compareRepo.repoId, PR?.compareBranch)}
+          >
+            {isMergeInSameRepo ? PR?.compareBranch : `${shortenAddress(forkRepo?.owner ?? '')}:${PR?.compareBranch}`}
+          </span>{' '}
+          into{' '}
+          <span
+            className="text-primary-600 bg-primary-200 px-1 cursor-pointer"
+            onClick={() => gotoBranch(PR.baseRepo.repoId, PR?.baseBranch)}
+          >
+            {isMergeInSameRepo ? PR?.baseBranch : `${shortenAddress(repo.owner)}:${PR?.baseBranch}`}
+          </span>
         </div>
       </div>
     </div>

--- a/src/pages/pull/read/index.tsx
+++ b/src/pages/pull/read/index.tsx
@@ -1,5 +1,5 @@
 import { Tab } from '@headlessui/react'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import Lottie from 'react-lottie'
 import { useLocation, useParams } from 'react-router-dom'
 
@@ -16,6 +16,7 @@ const activeClasses = 'border-b-[2px] border-primary-600 text-gray-900 font-medi
 export default function ReadPullRequest() {
   const location = useLocation()
   const { id, pullId } = useParams()
+  const [compareRepoOwner, setCompareRepoOwner] = useState('')
   const [
     selectedRepo,
     forkRepo,
@@ -48,12 +49,18 @@ export default function ReadPullRequest() {
 
       if (!PR) return
 
-      const compareIsFork =
-        Object.values(selectedRepo.repo.forks).findIndex((fork) => fork.id === PR.compareRepo.repoId) > -1
+      let compareIsFork = false
 
-      if (PR.baseRepo.repoId !== PR.compareRepo.repoId && compareIsFork) {
-        fetchAndLoadForkRepository(PR.compareRepo.repoId)
-        //
+      if (PR.baseRepo.repoId !== PR.compareRepo.repoId) {
+        const forks = Object.values(selectedRepo.repo.forks)
+        const forkRepoIndex = forks.findIndex((fork) => fork.id === PR.compareRepo.repoId)
+        compareIsFork = forkRepoIndex > -1
+
+        if (compareIsFork) {
+          setCompareRepoOwner(forks[forkRepoIndex].owner)
+          fetchAndLoadForkRepository(PR.compareRepo.repoId)
+          //
+        }
       }
 
       const params = {
@@ -128,7 +135,7 @@ export default function ReadPullRequest() {
   return (
     <div className="h-full flex-1 flex flex-col max-w-[1280px] mx-auto w-full mt-6 gap-8">
       {/* PR Meta Details open */}
-      {PR && <PullRequestHeader PR={PR} repo={selectedRepo.repo!} forkRepo={forkRepo.repo} />}
+      {PR && <PullRequestHeader PR={PR} repo={selectedRepo.repo!} compareRepoOwner={compareRepoOwner} />}
       {/* PR Meta Details close */}
       <div className="flex flex-col flex-1">
         <Tab.Group>

--- a/src/pages/pull/read/index.tsx
+++ b/src/pages/pull/read/index.tsx
@@ -128,7 +128,7 @@ export default function ReadPullRequest() {
   return (
     <div className="h-full flex-1 flex flex-col max-w-[1280px] mx-auto w-full mt-6 gap-8">
       {/* PR Meta Details open */}
-      {PR && <PullRequestHeader PR={PR} />}
+      {PR && <PullRequestHeader PR={PR} repo={selectedRepo.repo!} forkRepo={forkRepo.repo} />}
       {/* PR Meta Details close */}
       <div className="flex flex-col flex-1">
         <Tab.Group>


### PR DESCRIPTION
## Summary

This PR improves the PR UI with clickable links (`repos branches and user address`) and repo `owner/name` format.
- Merge between different repo
![image](https://github.com/labscommunity/protocol-land/assets/11836100/1c3d8601-b503-46ae-9dae-8b2349544fc6)
  - [Demo PR URL](https://protocol-land-bql0sqr4v-community-labs.vercel.app/#/repository/b0076bae-63fb-4033-b459-ed810302d869/pull/1)
- Merge between same repo
![image](https://github.com/labscommunity/protocol-land/assets/11836100/4362454a-6c1d-44e0-866d-34e73745f1a3)
  - [Demo PR URL](https://protocol-land-bql0sqr4v-community-labs.vercel.app/#/repository/b3551149-8ef5-411a-969e-93d22967c0b0/pull/1)

- Aditionally, Show `No description provided.` when description not provided.
![image](https://github.com/labscommunity/protocol-land/assets/11836100/77734b7e-9844-4517-9a7b-27bbd3c1299c)
