### PR TITLE
fix: check repo exists before creating or forking

### DIFF
--- a/warp/protocol-land/actions/repository.ts
+++ b/warp/protocol-land/actions/repository.ts
@@ -25,6 +25,10 @@ export async function initializeNewRepository(
     throw new ContractError('Repository with the same name already exists.')
   }
 
+  if (state.repos[payload.id]) {
+    throw new ContractError('Repository already exists.')
+  }
+
   const repo: Repo = {
     id: payload.id,
     name: payload.name,
@@ -69,6 +73,10 @@ export async function forkRepository(
 
   if (callerRepos[lowercasedRepoName]) {
     throw new ContractError('Repository with the same name already exists.')
+  }
+
+  if (state.repos[payload.id]) {
+    throw new ContractError('Repository already exists.')
   }
 
   const repo: Repo = {


### PR DESCRIPTION
## Summary

This PR makes sure no repo with id in the payload exists before initializing a new repo or forking a repo.