### PR TITLE
feat: support private repos

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -30,8 +30,9 @@ module.exports = {
         '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
         '@typescript-eslint/no-var-requires': 'off',
         '@typescript-eslint/prefer-arrow-callback': 'off',
-        '@typescript-eslint/ban-types': 'off'
+        '@typescript-eslint/ban-types': 'off',
+        '@typescript-eslint/ban-ts-comment': 'off'
       }
     }
   ]
-};
+}

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -20,7 +20,7 @@ const __dirname = path.resolve()
 // read contract source logic from 'handle.js' and encode it
 const state = fs.readFileSync(path.join(__dirname, 'warp/protocol-land/initial-state.json'), 'utf-8')
 const contractSource = fs.readFileSync(path.join(__dirname, 'contracts-dist/repository-contract.js'), 'utf-8')
-const contract = warp.contract('UX6S6CxyxII_vGRbXd9EVlyG7Sv-9nf1TxLEFYUi0Qs').connect(key)
+const contract = warp.contract('w5ZU15Y2cLzZlu3jewauIlnzbKw-OAxbN9G5TbuuiDQ').connect(key)
 
 if (evolve) {
   const newSource = await warp.createSource({ src: contractSource }, new ArweaveSigner(key))

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -20,7 +20,7 @@ const __dirname = path.resolve()
 // read contract source logic from 'handle.js' and encode it
 const state = fs.readFileSync(path.join(__dirname, 'warp/protocol-land/initial-state.json'), 'utf-8')
 const contractSource = fs.readFileSync(path.join(__dirname, 'contracts-dist/repository-contract.js'), 'utf-8')
-const contract = warp.contract('w5ZU15Y2cLzZlu3jewauIlnzbKw-OAxbN9G5TbuuiDQ').connect(key)
+const contract = warp.contract('UX6S6CxyxII_vGRbXd9EVlyG7Sv-9nf1TxLEFYUi0Qs').connect(key)
 
 if (evolve) {
   const newSource = await warp.createSource({ src: contractSource }, new ArweaveSigner(key))

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,4 +1,4 @@
-export const CONTRACT_TX_ID = 'UX6S6CxyxII_vGRbXd9EVlyG7Sv-9nf1TxLEFYUi0Qs'
+export const CONTRACT_TX_ID = 'w5ZU15Y2cLzZlu3jewauIlnzbKw-OAxbN9G5TbuuiDQ'
 export const VITE_GA_TRACKING_ID = 'G-L433HSR0D0'
 export const AMPLITUDE_TRACKING_ID = '92a463755ed8c8b96f0f2353a37b7b2'
 export const PL_REPO_ID = '6ace6247-d267-463d-b5bd-7e50d98c3693'

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,4 +1,4 @@
-export const CONTRACT_TX_ID = 'w5ZU15Y2cLzZlu3jewauIlnzbKw-OAxbN9G5TbuuiDQ'
+export const CONTRACT_TX_ID = 'UX6S6CxyxII_vGRbXd9EVlyG7Sv-9nf1TxLEFYUi0Qs'
 export const VITE_GA_TRACKING_ID = 'G-L433HSR0D0'
 export const AMPLITUDE_TRACKING_ID = '92a463755ed8c8b96f0f2353a37b7b2'
 export const PL_REPO_ID = '6ace6247-d267-463d-b5bd-7e50d98c3693'

--- a/src/lib/git/pull-request.ts
+++ b/src/lib/git/pull-request.ts
@@ -142,7 +142,9 @@ export async function mergePullRequest({
   dryRun,
   repoId,
   prId,
-  fork
+  fork,
+  isPrivate,
+  privateStateTxId
 }: MergePullRequestOptions) {
   const { error } = await withAsync(() =>
     git.merge({
@@ -174,7 +176,7 @@ export async function mergePullRequest({
     if (fork) {
       await deleteBranch({ fs, dir, name: compare })
     }
-    await postUpdatedRepo({ fs, dir, owner: author, id: repoId })
+    await postUpdatedRepo({ fs, dir, owner: author, id: repoId, isPrivate, privateStateTxId })
 
     await waitFor(1000)
 
@@ -319,6 +321,8 @@ type MergePullRequestOptions = {
   repoId: string
   prId: number
   fork: boolean
+  isPrivate: boolean
+  privateStateTxId?: string
 }
 
 type GetStatusMatrixOfTwoBranchesOptions = {

--- a/src/lib/git/repo.ts
+++ b/src/lib/git/repo.ts
@@ -315,14 +315,14 @@ export async function addDeployment(deployment: Partial<Deployment>, repoId: str
   return latestDeployment
 }
 
-export async function addContributor(address: string, repoId: string) {
+export async function inviteContributor(address: string, repoId: string) {
   const userSigner = new InjectedArweaveSigner(window.arweaveWallet)
   await userSigner.setPublicKey()
 
   const contract = getWarpContract(CONTRACT_TX_ID, userSigner)
 
   await contract.writeInteraction({
-    function: 'addContributor',
+    function: 'inviteContributor',
     payload: {
       id: repoId,
       contributor: address

--- a/src/lib/git/repo.ts
+++ b/src/lib/git/repo.ts
@@ -417,7 +417,24 @@ export async function inviteContributor(address: string, repoId: string) {
   const userSigner = new InjectedArweaveSigner(window.arweaveWallet)
   await userSigner.setPublicKey()
 
+  const caller = await window.arweaveWallet.getActiveAddress()
+
   const contract = getWarpContract(CONTRACT_TX_ID, userSigner)
+
+  const dryRunResult = await contract.dryWrite(
+    {
+      function: 'inviteContributor',
+      payload: {
+        id: repoId,
+        contributor: address
+      }
+    },
+    caller
+  )
+
+  if (dryRunResult.type === 'error') {
+    throw dryRunResult.errorMessage
+  }
 
   await contract.writeInteraction({
     function: 'inviteContributor',

--- a/src/lib/git/repo.ts
+++ b/src/lib/git/repo.ts
@@ -22,11 +22,15 @@ const arweave = new Arweave({
   protocol: 'https'
 })
 
-export async function postNewRepo({ id, title, description, file, owner }: any) {
+export async function postNewRepo({ id, title, description, file, owner, visibility }: any) {
   const userSigner = new InjectedArweaveSigner(window.arweaveWallet)
   await userSigner.setPublicKey()
 
   const data = (await toArrayBuffer(file)) as ArrayBuffer
+
+  if (visibility === 'private') {
+    // Enc
+  }
 
   await waitFor(500)
 

--- a/src/lib/private-repos/crypto/decrypt.ts
+++ b/src/lib/private-repos/crypto/decrypt.ts
@@ -1,0 +1,19 @@
+export async function decryptAesKeyWithPrivateKey(encryptedAesKey: Uint8Array) {
+  const decryptedAesKey = await window.arweaveWallet.decrypt(encryptedAesKey, {
+    // @ts-ignore
+    name: 'RSA-OAEP',
+    hash: 'SHA-256'
+  })
+
+  return decryptedAesKey
+}
+
+export async function decryptFileWithAesGcm(encryptedFile: ArrayBuffer, decryptedAesKey: ArrayBuffer, iv: Uint8Array) {
+  const aesKey = await window.crypto.subtle.importKey('raw', decryptedAesKey, { name: 'AES-GCM', length: 256 }, true, [
+    'decrypt'
+  ])
+
+  const decryptedFile = await window.crypto.subtle.decrypt({ name: 'AES-GCM', iv: iv }, aesKey, encryptedFile)
+
+  return decryptedFile
+}

--- a/src/lib/private-repos/crypto/encrypt.ts
+++ b/src/lib/private-repos/crypto/encrypt.ts
@@ -1,0 +1,32 @@
+export async function encryptFileWithAesGcm(file: ArrayBuffer) {
+  const aesKey = await window.crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt'])
+
+  const iv = window.crypto.getRandomValues(new Uint8Array(16))
+  const encryptedFile = await window.crypto.subtle.encrypt({ name: 'AES-GCM', iv: iv }, aesKey, file)
+
+  return { encryptedFile, aesKey, iv }
+}
+
+export async function encryptAesKeyWithPublicKeys(aesKey: CryptoKey, publicKeyArray: JsonWebKey[]) {
+  const encryptedKeys = []
+
+  for (const publicKeyJwk of publicKeyArray) {
+    const publicKey = await window.crypto.subtle.importKey(
+      'jwk',
+      publicKeyJwk,
+      { name: 'RSA-OAEP', hash: 'SHA-256' },
+      true,
+      ['encrypt']
+    )
+
+    const encryptedKey = await window.crypto.subtle.encrypt(
+      { name: 'RSA-OAEP' },
+      publicKey,
+      await window.crypto.subtle.exportKey('raw', aesKey)
+    )
+
+    encryptedKeys.push(encryptedKey)
+  }
+
+  return encryptedKeys
+}

--- a/src/lib/private-repos/crypto/encrypt.ts
+++ b/src/lib/private-repos/crypto/encrypt.ts
@@ -1,14 +1,24 @@
+import Arweave from 'arweave'
+
+import { deriveAddress } from '../utils'
+
+const arweave = Arweave.init({
+  host: 'ar-io.net',
+  port: 443,
+  protocol: 'https'
+})
+
 export async function encryptFileWithAesGcm(file: ArrayBuffer) {
   const aesKey = await window.crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt'])
 
   const iv = window.crypto.getRandomValues(new Uint8Array(16))
   const encryptedFile = await window.crypto.subtle.encrypt({ name: 'AES-GCM', iv: iv }, aesKey, file)
 
-  return { encryptedFile, aesKey, iv }
+  return { encryptedFile, aesKey, iv: arweave.utils.bufferTob64Url(iv) }
 }
 
 export async function encryptAesKeyWithPublicKeys(aesKey: CryptoKey, publicKeyArray: JsonWebKey[]) {
-  const encryptedKeys = []
+  const encryptedKeys: Record<string, string> = Object.create(null)
 
   for (const publicKeyJwk of publicKeyArray) {
     const publicKey = await window.crypto.subtle.importKey(
@@ -25,7 +35,9 @@ export async function encryptAesKeyWithPublicKeys(aesKey: CryptoKey, publicKeyAr
       await window.crypto.subtle.exportKey('raw', aesKey)
     )
 
-    encryptedKeys.push(encryptedKey)
+    const hash = await deriveAddress(publicKeyJwk.n!)
+
+    encryptedKeys[hash] = arweave.utils.bufferTob64Url(new Uint8Array(encryptedKey))
   }
 
   return encryptedKeys

--- a/src/lib/private-repos/utils.ts
+++ b/src/lib/private-repos/utils.ts
@@ -1,0 +1,8 @@
+export function strToJwkPubKey(pubKey: string) {
+  return {
+    e: 'AQAB',
+    ext: true,
+    kty: 'RSA',
+    n: pubKey
+  }
+}

--- a/src/lib/private-repos/utils.ts
+++ b/src/lib/private-repos/utils.ts
@@ -1,3 +1,5 @@
+import Arweave from 'arweave'
+
 export function strToJwkPubKey(pubKey: string) {
   return {
     e: 'AQAB',
@@ -5,4 +7,17 @@ export function strToJwkPubKey(pubKey: string) {
     kty: 'RSA',
     n: pubKey
   }
+}
+
+export async function deriveAddress(publicKey: string) {
+  const arweave = Arweave.init({
+    host: 'ar-io.net',
+    port: 443,
+    protocol: 'https'
+  })
+
+  const pubKeyBuf = arweave.utils.b64UrlToBuffer(publicKey)
+  const sha512DigestBuf = await crypto.subtle.digest('SHA-512', pubKeyBuf)
+
+  return arweave.utils.bufferTob64Url(new Uint8Array(sha512DigestBuf))
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,7 +14,15 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <ArweaveWalletKit
     config={{
       strategies: [new ArConnectStrategy(), new BrowserWalletStrategy()],
-      permissions: ['ACCESS_ADDRESS', 'SIGN_TRANSACTION', 'ACCESS_PUBLIC_KEY', 'SIGNATURE', 'DISPATCH'],
+      permissions: [
+        'ACCESS_ADDRESS',
+        'SIGN_TRANSACTION',
+        'ACCESS_PUBLIC_KEY',
+        'SIGNATURE',
+        'DISPATCH',
+        'DECRYPT',
+        'ENCRYPT'
+      ],
       ensurePermissions: true
     }}
     theme={{

--- a/src/pages/home/components/NewRepoModal.tsx
+++ b/src/pages/home/components/NewRepoModal.tsx
@@ -1,7 +1,7 @@
 import { Dialog, Transition } from '@headlessui/react'
 import { yupResolver } from '@hookform/resolvers/yup'
 import clsx from 'clsx'
-import React, { Fragment } from 'react'
+import React, { ChangeEvent, Fragment } from 'react'
 import { useForm } from 'react-hook-form'
 import toast from 'react-hot-toast'
 import SVG from 'react-inlinesvg'
@@ -39,6 +39,7 @@ const schema = yup
 
 export default function NewRepoModal({ setIsOpen, isOpen }: NewRepoModalProps) {
   const [isSubmitting, setIsSubmitting] = React.useState(false)
+  const [visibility, setVisibility] = React.useState('public')
   const navigate = useNavigate()
   const [authState] = useGlobalStore((state) => [state.authState])
   const {
@@ -75,7 +76,7 @@ export default function NewRepoModal({ setIsOpen, isOpen }: NewRepoModalProps) {
       if (createdRepo && createdRepo.commit && createdRepo.repoBlob) {
         const { repoBlob } = createdRepo
 
-        const result = await postNewRepo({ id, title, description, file: repoBlob, owner: authState.address })
+        const result = await postNewRepo({ id, title, description, file: repoBlob, owner: authState.address, visibility })
 
         if (result.txResponse) {
           trackGoogleAnalyticsEvent('Repository', 'Successfully created a repo', 'Create new repo', {
@@ -89,6 +90,10 @@ export default function NewRepoModal({ setIsOpen, isOpen }: NewRepoModalProps) {
     } catch (error) {
       trackGoogleAnalyticsEvent('Repository', 'Failed to create a new repo', 'Create new repo')
     }
+  }
+
+  function handleRepositoryVisibilityChange(event: ChangeEvent<HTMLInputElement>) {
+    setVisibility(event.target.value)
   }
 
   return (
@@ -156,6 +161,32 @@ export default function NewRepoModal({ setIsOpen, isOpen }: NewRepoModalProps) {
                     {errors.description && (
                       <p className="text-red-500 text-sm italic mt-2">{errors.description?.message}</p>
                     )}
+                  </div>
+                  <div className="flex flex-col">
+                    <h1 className="mb-1 text-sm font-medium text-gray-600">Repository visibility</h1>
+                    <div className="flex flex-row gap-2">
+                      <label htmlFor="radio-1" className="flex items-center">
+                        <input
+                          type="radio"
+                          name="radio-group"
+                          onChange={handleRepositoryVisibilityChange}
+                          value="public"
+                          defaultChecked
+                          className="mr-2 rounded-full h-4 w-4 checked:accent-primary-700 accent-primary-600 bg-white focus:ring-primary-600  outline-none"
+                        />
+                        Public
+                      </label>
+                      <label htmlFor="radio-2" className="flex items-center">
+                        <input
+                          type="radio"
+                          name="radio-group"
+                          onChange={handleRepositoryVisibilityChange}
+                          value="private"
+                          className="mr-2 rounded-full h-4 w-4 checked:accent-primary-700 accent-primary-600 bg-white focus:ring-primary-600  outline-none"
+                        />
+                        Private
+                      </label>
+                    </div>
                   </div>
                   <div className="py-1">
                     <CostEstimatesToolTip fileSizes={[2740]} />

--- a/src/pages/repository/Repository.tsx
+++ b/src/pages/repository/Repository.tsx
@@ -75,14 +75,15 @@ export default function Repository() {
     branchAbscent
 
   const isReady = selectedRepo.status === 'SUCCESS'
-  const redirectToInviteScreen = selectedRepo.isInvitedContributor && selectedRepo.isPrivateRepo
+  const redirectToInviteScreenPrivate = selectedRepo.isInvitedContributor && selectedRepo.isPrivateRepo
 
-  if (redirectToInviteScreen) return <AcceptInvite repo={selectedRepo.repo} />
+  if (redirectToInviteScreenPrivate) return <AcceptInvite repo={selectedRepo.repo} />
 
   if (isPageNotFound) return <PageNotFound />
 
   return (
     <div className="h-full flex-1 flex flex-col max-w-[1280px] mx-auto w-full mt-6 gap-2">
+      {/* <div className="w-full h-[70px] bg-primary-300 mb-4 rounded-md"></div> */}
       <RepoHeader
         owner={authState.address}
         isLoading={!isReady}

--- a/src/pages/repository/Repository.tsx
+++ b/src/pages/repository/Repository.tsx
@@ -8,6 +8,7 @@ import PageNotFound from '@/components/PageNotFound'
 import { trackGoogleAnalyticsEvent } from '@/helpers/google-analytics'
 import { useGlobalStore } from '@/stores/globalStore'
 
+import AcceptInvite from './components/AcceptInvite'
 import RepoHeader from './components/RepoHeader'
 import { rootTabConfig } from './config/rootTabConfig'
 
@@ -74,6 +75,9 @@ export default function Repository() {
     branchAbscent
 
   const isReady = selectedRepo.status === 'SUCCESS'
+  const redirectToInviteScreen = selectedRepo.isInvitedContributor && selectedRepo.isPrivateRepo
+
+  if (redirectToInviteScreen) return <AcceptInvite repo={selectedRepo.repo} />
 
   if (isPageNotFound) return <PageNotFound />
 

--- a/src/pages/repository/components/AcceptInvite.tsx
+++ b/src/pages/repository/components/AcceptInvite.tsx
@@ -79,7 +79,7 @@ export default function AcceptInvite({ repo }: { repo: Repo | null }) {
           <div className="flex justify-center mt-3 gap-3">
             <Button
               isLoading={isRejectLoading}
-              disabled={isRejectLoading}
+              disabled={isRejectLoading || isAcceptLoading}
               variant="primary-outline"
               className="px-16 justify-center"
               onClick={handleDeclineInviteClick}
@@ -88,7 +88,7 @@ export default function AcceptInvite({ repo }: { repo: Repo | null }) {
             </Button>
             <Button
               isLoading={isAcceptLoading}
-              disabled={isAcceptLoading}
+              disabled={isAcceptLoading || isRejectLoading}
               variant="primary-solid"
               className="px-16 justify-center"
               onClick={handleAcceptInviteClick}

--- a/src/pages/repository/components/AcceptInvite.tsx
+++ b/src/pages/repository/components/AcceptInvite.tsx
@@ -1,0 +1,103 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+import { Button } from '@/components/common/buttons'
+import { shortenAddress } from '@/helpers/shortenAddress'
+import { useGlobalStore } from '@/stores/globalStore'
+import { Repo } from '@/types/repository'
+
+export default function AcceptInvite({ repo }: { repo: Repo | null }) {
+  const [isAcceptLoading, setAcceptIsLoading] = React.useState(false)
+  const [isRejectLoading, setIsRejectLoading] = React.useState(false)
+  const [status, setStatus] = React.useState('IDLE')
+  const [acceptContributor, rejectContributor] = useGlobalStore((state) => [
+    state.repoCoreActions.acceptContributor,
+    state.repoCoreActions.rejectContributor
+  ])
+
+  async function handleAcceptInviteClick() {
+    setAcceptIsLoading(true)
+    await acceptContributor()
+    setAcceptIsLoading(false)
+    setStatus('SUCCESS')
+  }
+
+  async function handleDeclineInviteClick() {
+    //
+    setIsRejectLoading(true)
+    await rejectContributor()
+    setIsRejectLoading(true)
+    setStatus('REJECTED')
+  }
+
+  if (status === 'SUCCESS' && repo) {
+    return (
+      <div className="flex justify-center h-screen">
+        <div className="text-center mt-[20vh] w-[500px]">
+          <p className="text-2xl text-gray-600 mb-8">
+            You've successfully accepted the invite to collaborate on{' '}
+            <b>
+              <i>{repo.name}</i>
+            </b>
+          </p>
+          <p className="text-gray-500 mb-4">Please wait while admin grant you access.</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (status === 'REJECTED' && repo) {
+    return (
+      <div className="flex justify-center h-screen">
+        <div className="text-center mt-[20vh] w-[500px]">
+          <p className="text-2xl text-gray-600 mb-8">
+            You've successfully rejected the invite to collaborate on{' '}
+            <b>
+              <i>{repo.name}</i>
+            </b>
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  if (repo) {
+    return (
+      <div className="flex justify-center h-screen">
+        <div className="text-center mt-[20vh] w-[500px]">
+          <p className="text-2xl text-gray-600 mb-8">
+            You've been invited by{' '}
+            <span className="text-primary-600 hover:underline">
+              <Link to={`/user/${repo.owner}`}>{shortenAddress(repo.owner, 6)}</Link>
+            </span>{' '}
+            to collaborate on{' '}
+            <b>
+              <i>{repo.name}</i>
+            </b>
+          </p>
+          <p className="text-gray-500 mb-4">You can accept or decline this invitation.</p>
+          <div className="flex justify-center mt-3 gap-3">
+            <Button
+              isLoading={isRejectLoading}
+              disabled={isRejectLoading}
+              variant="primary-outline"
+              className="px-16 justify-center"
+              onClick={handleDeclineInviteClick}
+            >
+              Decline
+            </Button>
+            <Button
+              isLoading={isAcceptLoading}
+              disabled={isAcceptLoading}
+              variant="primary-solid"
+              className="px-16 justify-center"
+              onClick={handleAcceptInviteClick}
+            >
+              Accept
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/pages/repository/components/RepoHeader.tsx
+++ b/src/pages/repository/components/RepoHeader.tsx
@@ -74,7 +74,9 @@ export default function RepoHeader({ repo, isLoading, owner, parentRepo }: Props
 
   function handleForkButtonClick() {
     if (owner && owner === repo.owner) {
-      toast.error('Cannot fork your own repo')
+      toast.error('Cannot fork your own repo.')
+    } else if (repo.private) {
+      toast.error('Cannot fork private repo.')
     } else {
       setIsForkModalOpen(true)
     }

--- a/src/pages/repository/components/tabs/settings-tab/Contributors.tsx
+++ b/src/pages/repository/components/tabs/settings-tab/Contributors.tsx
@@ -114,7 +114,7 @@ export default function Contributors() {
   }
 
   async function handleCancelInviteClick(invite: ContributorInvite) {
-    if (!repo || !repo.privateStateTxId) return false
+    if (!repo) return false
 
     try {
       setIsGrantAccessLoading(true)

--- a/src/pages/repository/components/tabs/settings-tab/Contributors.tsx
+++ b/src/pages/repository/components/tabs/settings-tab/Contributors.tsx
@@ -17,9 +17,9 @@ const addressSchema = yup
   .required()
 
 export default function Contributors() {
-  const [repo, addContributor, isRepoOwner] = useGlobalStore((state) => [
+  const [repo, inviteContributor, isRepoOwner] = useGlobalStore((state) => [
     state.repoCoreState.selectedRepo.repo,
-    state.repoCoreActions.addContributor,
+    state.repoCoreActions.inviteContributor,
     state.repoCoreActions.isRepoOwner
   ])
   const {
@@ -39,7 +39,7 @@ export default function Contributors() {
       if (isContributor || isOwner) {
         toast.error('You already have permissions to this repo')
       } else {
-        await addContributor(data.address)
+        await inviteContributor(data.address)
         resetField('address')
         toast.success('Successfully added a contributor')
       }
@@ -57,7 +57,7 @@ export default function Contributors() {
         <div className="flex flex-col">
           <div className="w-[50%]">
             <label htmlFor="title" className="block mb-1 text-sm font-medium text-gray-600">
-              Add new contributor
+              Invite new contributor
             </label>
             <div className="flex items-center gap-4">
               <input
@@ -71,7 +71,7 @@ export default function Contributors() {
                 disabled={!repoOwner}
               />
               <Button disabled={!repoOwner} onClick={handleSubmit(handleAddButtonClick)} variant="primary-solid">
-                Add
+                Invite
               </Button>
             </div>
           </div>

--- a/src/pages/repository/components/tabs/settings-tab/Contributors.tsx
+++ b/src/pages/repository/components/tabs/settings-tab/Contributors.tsx
@@ -22,12 +22,26 @@ const addressSchema = yup
 export default function Contributors() {
   const [isLoading, setIsLoading] = React.useState(false)
   const [isGrantAccessLoading, setIsGrantAccessLoading] = React.useState(false)
-  const [repo, inviteContributor, addContributor, cancelContributor, isRepoOwner] = useGlobalStore((state) => [
+  const [isAcceptLoading, setAcceptIsLoading] = React.useState(false)
+  const [isRejectLoading, setIsRejectLoading] = React.useState(false)
+  const [
+    address,
+    repo,
+    inviteContributor,
+    addContributor,
+    cancelContributor,
+    isRepoOwner,
+    acceptContributor,
+    rejectContributor
+  ] = useGlobalStore((state) => [
+    state.authState.address,
     state.repoCoreState.selectedRepo.repo,
     state.repoCoreActions.inviteContributor,
     state.repoCoreActions.addContributor,
     state.repoCoreActions.cancelContributor,
-    state.repoCoreActions.isRepoOwner
+    state.repoCoreActions.isRepoOwner,
+    state.repoCoreActions.acceptContributor,
+    state.repoCoreActions.rejectContributor
   ])
   const {
     register,
@@ -145,6 +159,44 @@ export default function Contributors() {
     )
   }
 
+  async function handleAcceptInviteClick() {
+    setAcceptIsLoading(true)
+    await acceptContributor()
+    setAcceptIsLoading(false)
+  }
+
+  async function handleDeclineInviteClick() {
+    //
+    setIsRejectLoading(true)
+    await rejectContributor()
+    setIsRejectLoading(true)
+  }
+
+  const inviteActionsMapForContributor = {
+    INVITED: () => (
+      <div className="flex gap-2 items-center">
+        <Button
+          isLoading={isRejectLoading}
+          disabled={isAcceptLoading || isRejectLoading}
+          onClick={handleDeclineInviteClick}
+          variant="primary-outline"
+          className="!py-1 border-red-400 text-red-400 hover:bg-red-50"
+        >
+          Reject
+        </Button>
+        <Button
+          isLoading={isAcceptLoading}
+          disabled={isAcceptLoading || isRejectLoading}
+          onClick={handleAcceptInviteClick}
+          variant="primary-outline"
+          className="!py-1"
+        >
+          Accept
+        </Button>
+      </div>
+    )
+  }
+
   return (
     <div className="flex flex-col gap-4">
       <div className="w-full border-b-[1px] border-[#cbc9f6] py-1">
@@ -213,12 +265,17 @@ export default function Contributors() {
           {repo &&
             repo?.contributorInvites?.filter(filterContributorInvited).map((invite) => {
               const InviteActionComponent = inviteActionsMap[invite.status as keyof typeof inviteActionsMap]
+              const ContributorInviteActionComponent =
+                inviteActionsMapForContributor[invite.status as keyof typeof inviteActionsMapForContributor]
               return (
                 <div className="flex bg-gray-50 cursor-pointer hover:bg-primary-50 text-gray-600 hover:text-gray-900 items-center gap-4 py-[10px] px-4 border-b-[1px] border-gray-300 last:border-b-0">
                   <div className="w-[60%]">{invite.address}</div>
                   <div className="w-[25%] capitalize">{invite.status.toLowerCase()}</div>
                   <div className="w-[25%] capitalize">
                     {repoOwner && InviteActionComponent && <InviteActionComponent invite={invite} />}
+                    {address === invite.address && ContributorInviteActionComponent && (
+                      <ContributorInviteActionComponent />
+                    )}
                   </div>
                 </div>
               )

--- a/src/pages/repository/hooks/useCommit.ts
+++ b/src/pages/repository/hooks/useCommit.ts
@@ -28,7 +28,8 @@ type AddFilesOptions = {
 }
 
 export default function useCommit() {
-  const [repoCommitsG, setRepoCommitsG] = useGlobalStore((state) => [
+  const [selectedRepo, repoCommitsG, setRepoCommitsG] = useGlobalStore((state) => [
+    state.repoCoreState.selectedRepo,
     state.repoCoreState.git.commits,
     state.repoCoreActions.git.setCommits
   ])
@@ -80,7 +81,9 @@ export default function useCommit() {
 
     if (commitError || !commitSHA) throw trackAndThrowError('Failed to commit files', name, id)
 
-    const { error, response } = await withAsync(() => postUpdatedRepo({ fs, dir, owner, id }))
+    const isPrivate = selectedRepo.repo?.private || false
+    const privateStateTxId = selectedRepo.repo?.privateStateTxId
+    const { error, response } = await withAsync(() => postUpdatedRepo({ fs, dir, owner, id, isPrivate, privateStateTxId }))
 
     if (error) throw trackAndThrowError('Failed to update repository', name, id)
 

--- a/src/stores/pull-request/actions/index.ts
+++ b/src/stores/pull-request/actions/index.ts
@@ -136,10 +136,23 @@ export async function mergePR(
   branchA: string,
   branchB: string,
   author: string,
-  fork: boolean = false
+  fork: boolean = false,
+  isPrivate: boolean = false,
+  privateStateTxId: string | undefined
 ) {
   const fs = fsWithName(repoId)
   const dir = `/${name}`
 
-  return mergePullRequest({ fs, dir, base: branchA, compare: branchB, author, prId, repoId, fork })
+  return mergePullRequest({
+    fs,
+    dir,
+    base: branchA,
+    compare: branchB,
+    author,
+    prId,
+    repoId,
+    fork,
+    isPrivate,
+    privateStateTxId
+  })
 }

--- a/src/stores/pull-request/index.ts
+++ b/src/stores/pull-request/index.ts
@@ -221,7 +221,7 @@ const createPullRequestSlice: StateCreator<CombinedSlices, [['zustand/immer', ne
       }
 
       const { error } = await withAsync(() =>
-        mergePR(repo.id, id, repo.name, baseBranch, compareBranch, author!, isFork)
+        mergePR(repo.id, id, repo.name, baseBranch, compareBranch, author!, isFork, repo.private, repo.privateStateTxId)
       )
 
       if (!error) {

--- a/src/stores/repository-core/actions/git.ts
+++ b/src/stores/repository-core/actions/git.ts
@@ -111,7 +111,7 @@ export async function decryptRepo(repoArrayBuf: ArrayBuffer, privateStateTxId: s
   const pubKey = await window.arweaveWallet.getActivePublicKey()
   const address = await deriveAddress(pubKey)
 
-  const encAesKeyStr = privateState.keys[address]
+  const encAesKeyStr = privateState.encKeys[address]
   const encAesKeyBuf = arweave.utils.b64UrlToBuffer(encAesKeyStr)
 
   const aesKey = (await decryptAesKeyWithPrivateKey(encAesKeyBuf)) as unknown as ArrayBuffer

--- a/src/stores/repository-core/actions/git.ts
+++ b/src/stores/repository-core/actions/git.ts
@@ -1,9 +1,14 @@
+import Arweave from 'arweave'
+
 import { waitFor } from '@/helpers/waitFor'
 import { withAsync } from '@/helpers/withAsync'
 import { importRepoFromBlob, unmountRepoFromBrowser } from '@/lib/git'
 import { fsWithName } from '@/lib/git/helpers/fsWithName'
 import { getOidFromRef, readFileFromOid, readFilesFromOid } from '@/lib/git/helpers/oid'
 import { packGitRepo } from '@/lib/git/helpers/zipUtils'
+import { decryptAesKeyWithPrivateKey, decryptFileWithAesGcm } from '@/lib/private-repos/crypto/decrypt'
+import { deriveAddress } from '@/lib/private-repos/utils'
+import { PrivateState } from '@/types/repository'
 
 export async function getOidOfHeadRef(id: string, name: string) {
   const fs = fsWithName(id)
@@ -48,11 +53,15 @@ export async function saveRepository(id: string, name: string) {
   document.body.removeChild(downloadLink)
 }
 
-export async function loadRepository(id: string, name: string, dataTxId: string) {
+export async function loadRepository(id: string, name: string, dataTxId: string, privateStateTxId?: string) {
   await unmountRepository(id)
 
   const response = await fetch(`https://arweave.net/${dataTxId}`)
-  const repoArrayBuf = await response.arrayBuffer()
+  let repoArrayBuf = await response.arrayBuffer()
+
+  if (privateStateTxId) {
+    repoArrayBuf = await decryptRepo(repoArrayBuf, privateStateTxId)
+  }
 
   const fs = fsWithName(id)
   const dir = `/${name}`
@@ -84,4 +93,29 @@ export async function renameRepoDir(id: string, currentName: string, newName: st
 
 export async function unmountRepository(id: string) {
   return unmountRepoFromBrowser(id)
+}
+
+export async function decryptRepo(repoArrayBuf: ArrayBuffer, privateStateTxId: string): Promise<ArrayBuffer> {
+  const arweave = new Arweave({
+    host: 'ar-io.net',
+    port: 443,
+    protocol: 'https'
+  })
+
+  const response = await fetch(`https://arweave.net/${privateStateTxId}`)
+  const privateState = (await response.json()) as PrivateState
+
+  const ivArrBuff = arweave.utils.b64UrlToBuffer(privateState.iv)
+
+  //public key -> hash -> get the aes key from object
+  const pubKey = await window.arweaveWallet.getActivePublicKey()
+  const address = await deriveAddress(pubKey)
+
+  const encAesKeyStr = privateState.keys[address]
+  const encAesKeyBuf = arweave.utils.b64UrlToBuffer(encAesKeyStr)
+
+  const aesKey = (await decryptAesKeyWithPrivateKey(encAesKeyBuf)) as unknown as ArrayBuffer
+  const decryptedRepo = await decryptFileWithAesGcm(repoArrayBuf, aesKey, ivArrBuff)
+
+  return decryptedRepo
 }

--- a/src/stores/repository-core/actions/repoMeta.ts
+++ b/src/stores/repository-core/actions/repoMeta.ts
@@ -72,3 +72,28 @@ export const handleRejectContributor = async (id: string) => {
     payload: { id }
   })
 }
+
+export const handleCancelContributorInvite = async (id: string, contributor: string) => {
+  //rotate keys
+  const userSigner = new InjectedArweaveSigner(window.arweaveWallet)
+  await userSigner.setPublicKey()
+
+  const contract = getWarpContract(CONTRACT_TX_ID, userSigner)
+
+
+
+  await contract.writeInteraction({
+    function: 'cancelContributorInvite',
+    payload: { id, contributor }
+  })
+
+  const {
+    cachedValue: {
+      state: { repos }
+    }
+  } = await contract.readState()
+
+  const repo = repos[id] as Repo
+
+  return repo.contributorInvites
+}

--- a/src/stores/repository-core/actions/repoMeta.ts
+++ b/src/stores/repository-core/actions/repoMeta.ts
@@ -58,6 +58,16 @@ export const handleAcceptContributor = async (id: string, visibility: string, pr
     function: 'acceptContributorInvite',
     payload: { id, visibility, privateStateTxId }
   })
+
+  const {
+    cachedValue: {
+      state: { repos }
+    }
+  } = await contract.readState()
+
+  const repo = repos[id] as Repo
+
+  return { contributorInvites: repo.contributorInvites, contributors: repo.contributors }
 }
 
 export const handleRejectContributor = async (id: string) => {
@@ -71,6 +81,16 @@ export const handleRejectContributor = async (id: string) => {
     function: 'rejectContributorInvite',
     payload: { id }
   })
+
+  const {
+    cachedValue: {
+      state: { repos }
+    }
+  } = await contract.readState()
+
+  const repo = repos[id] as Repo
+
+  return { contributorInvites: repo.contributorInvites, contributors: repo.contributors }
 }
 
 export const handleCancelContributorInvite = async (id: string, contributor: string) => {
@@ -79,8 +99,6 @@ export const handleCancelContributorInvite = async (id: string, contributor: str
   await userSigner.setPublicKey()
 
   const contract = getWarpContract(CONTRACT_TX_ID, userSigner)
-
-
 
   await contract.writeInteraction({
     function: 'cancelContributorInvite',

--- a/src/stores/repository-core/actions/repoMeta.ts
+++ b/src/stores/repository-core/actions/repoMeta.ts
@@ -1,3 +1,5 @@
+import { InjectedArweaveSigner } from 'warp-contracts-plugin-signature'
+
 import { CONTRACT_TX_ID } from '@/helpers/constants'
 import getWarpContract from '@/helpers/getWrapContract'
 import { Repo, WarpReadState } from '@/types/repository'
@@ -43,4 +45,30 @@ export const searchRepositories = async (query: string): Promise<{ result: Repo[
   const ownerRepos = repoList.filter((item) => item.name.toLowerCase().includes(query.toLowerCase()))
 
   return { result: ownerRepos }
+}
+
+export const handleAcceptContributor = async (id: string, visibility: string, privateStateTxId: string | null) => {
+  //rotate keys
+  const userSigner = new InjectedArweaveSigner(window.arweaveWallet)
+  await userSigner.setPublicKey()
+
+  const contract = getWarpContract(CONTRACT_TX_ID, userSigner)
+
+  await contract.writeInteraction({
+    function: 'acceptContributorInvite',
+    payload: { id, visibility, privateStateTxId }
+  })
+}
+
+export const handleRejectContributor = async (id: string) => {
+  //rotate keys
+  const userSigner = new InjectedArweaveSigner(window.arweaveWallet)
+  await userSigner.setPublicKey()
+
+  const contract = getWarpContract(CONTRACT_TX_ID, userSigner)
+
+  await contract.writeInteraction({
+    function: 'rejectContributorInvite',
+    payload: { id }
+  })
 }

--- a/src/stores/repository-core/index.ts
+++ b/src/stores/repository-core/index.ts
@@ -3,8 +3,8 @@ import { StateCreator } from 'zustand'
 import { trackGoogleAnalyticsEvent } from '@/helpers/google-analytics'
 import { withAsync } from '@/helpers/withAsync'
 import {
-  addContributor,
   addDeployment,
+  inviteContributor,
   updateRepoDeploymentBranch,
   updateRepoDescription,
   updateRepoName
@@ -164,7 +164,7 @@ const createRepoCoreSlice: StateCreator<CombinedSlices, [['zustand/immer', never
         state.repoCoreState.selectedRepo.statistics = data
       })
     },
-    addContributor: async (address: string) => {
+    inviteContributor: async (address: string) => {
       const repo = get().repoCoreState.selectedRepo.repo
 
       if (!repo) {
@@ -173,7 +173,7 @@ const createRepoCoreSlice: StateCreator<CombinedSlices, [['zustand/immer', never
         return
       }
 
-      const { error } = await withAsync(() => addContributor(address, repo.id))
+      const { error } = await withAsync(() => inviteContributor(address, repo.id))
 
       if (!error) {
         set((state) => {
@@ -322,7 +322,12 @@ const createRepoCoreSlice: StateCreator<CombinedSlices, [['zustand/immer', never
 
       if (metaResponse) {
         const { error: repoFetchError, response: repoFetchResponse } = await withAsync(() =>
-          loadRepository(metaResponse.result.id, metaResponse.result.name, metaResponse.result.dataTxId, metaResponse.result.privateStateTxId)
+          loadRepository(
+            metaResponse.result.id,
+            metaResponse.result.name,
+            metaResponse.result.dataTxId,
+            metaResponse.result.privateStateTxId
+          )
         )
 
         if (repoFetchError) {

--- a/src/stores/repository-core/index.ts
+++ b/src/stores/repository-core/index.ts
@@ -227,7 +227,7 @@ const createRepoCoreSlice: StateCreator<CombinedSlices, [['zustand/immer', never
           throw new Error('Error fetching repository meta.')
         }
 
-        const { id: repoId, name, dataTxId, fork, parent } = metaResponse.result
+        const { id: repoId, name, dataTxId, fork, parent, privateStateTxId } = metaResponse.result
         let parentRepoName = null
 
         if (fork) {
@@ -247,7 +247,7 @@ const createRepoCoreSlice: StateCreator<CombinedSlices, [['zustand/immer', never
         }
 
         const { error: repoFetchError, response: repoFetchResponse } = await withAsync(() =>
-          loadRepository(repoId, name, dataTxId)
+          loadRepository(repoId, name, dataTxId, privateStateTxId)
         )
 
         // Always checkout default master branch if available
@@ -289,7 +289,7 @@ const createRepoCoreSlice: StateCreator<CombinedSlices, [['zustand/immer', never
       })
 
       const { error: repoFetchError, response: repoFetchResponse } = await withAsync(() =>
-        loadRepository(repo.id, repo.name, repo.dataTxId)
+        loadRepository(repo.id, repo.name, repo.dataTxId, repo.privateStateTxId)
       )
 
       if (repoFetchError) {
@@ -322,7 +322,7 @@ const createRepoCoreSlice: StateCreator<CombinedSlices, [['zustand/immer', never
 
       if (metaResponse) {
         const { error: repoFetchError, response: repoFetchResponse } = await withAsync(() =>
-          loadRepository(metaResponse.result.id, metaResponse.result.name, metaResponse.result.dataTxId)
+          loadRepository(metaResponse.result.id, metaResponse.result.name, metaResponse.result.dataTxId, metaResponse.result.privateStateTxId)
         )
 
         if (repoFetchError) {

--- a/src/stores/repository-core/index.ts
+++ b/src/stores/repository-core/index.ts
@@ -275,9 +275,15 @@ const createRepoCoreSlice: StateCreator<CombinedSlices, [['zustand/immer', never
         privateStateTxId = updatedPrivateStateTxId
       }
 
-      const { error } = await withAsync(() => handleAcceptContributor(repo.id, visibility, privateStateTxId))
+      const { error, response } = await withAsync(() => handleAcceptContributor(repo.id, visibility, privateStateTxId))
 
-      if (!error) {
+      if (!error && response) {
+        if (!repo.private) {
+          set((state) => {
+            state.repoCoreState.selectedRepo.repo!.contributorInvites = response.contributorInvites
+            state.repoCoreState.selectedRepo.repo!.contributors = response.contributors
+          })
+        }
         trackGoogleAnalyticsEvent('Repository', 'Accept contributor invite', 'Accept repo contributor invite', {
           repo_name: repo.name,
           repo_id: repo.id,
@@ -300,9 +306,14 @@ const createRepoCoreSlice: StateCreator<CombinedSlices, [['zustand/immer', never
         return
       }
 
-      const { error } = await withAsync(() => handleRejectContributor(repo.id))
+      const { error, response } = await withAsync(() => handleRejectContributor(repo.id))
 
-      if (!error) {
+      if (!error && response) {
+        if (!repo.private) {
+          set((state) => {
+            state.repoCoreState.selectedRepo.repo!.contributorInvites = response.contributorInvites
+          })
+        }
         trackGoogleAnalyticsEvent('Repository', 'Reject contributor invite', 'Reject repo contributor invite', {
           repo_name: repo.name,
           repo_id: repo.id,

--- a/src/stores/repository-core/types.ts
+++ b/src/stores/repository-core/types.ts
@@ -46,13 +46,14 @@ export type RepoCoreActions = {
   updateRepoName: (name: string) => Promise<void>
   updateRepoDescription: (description: string) => Promise<void>
   updateRepoDeploymentBranch: (deploymentBranch: string) => Promise<void>
-  inviteContributor: (address: string) => Promise<void>
+  inviteContributor: (address: string) => Promise<{ status: boolean; response?: any } | void>
   addDeployment: (
     deployment: Omit<Deployment, 'deployedBy' | 'branch' | 'timestamp'>
   ) => Promise<Deployment | undefined>
   addContributor: (address: string) => Promise<void>
   acceptContributor: () => Promise<void>
   rejectContributor: () => Promise<void>
+  cancelContributor: (contributor: string) => Promise<void>
   grantAccessToContributor: () => Promise<void>
   fetchAndLoadRepository: (id: string, branchName?: string) => Promise<string>
   fetchAndLoadParentRepository: (repo: Repo) => Promise<void>

--- a/src/stores/repository-core/types.ts
+++ b/src/stores/repository-core/types.ts
@@ -44,7 +44,7 @@ export type RepoCoreActions = {
   updateRepoName: (name: string) => Promise<void>
   updateRepoDescription: (description: string) => Promise<void>
   updateRepoDeploymentBranch: (deploymentBranch: string) => Promise<void>
-  addContributor: (address: string) => Promise<void>
+  inviteContributor: (address: string) => Promise<void>
   addDeployment: (
     deployment: Omit<Deployment, 'deployedBy' | 'branch' | 'timestamp'>
   ) => Promise<Deployment | undefined>

--- a/src/stores/repository-core/types.ts
+++ b/src/stores/repository-core/types.ts
@@ -17,6 +17,8 @@ export type RepoCoreState = {
       pullRequests: UserPROrIssue[]
       issues: UserPROrIssue[]
     }
+    isInvitedContributor: boolean
+    isPrivateRepo: boolean
   }
   parentRepo: {
     status: ApiStatus
@@ -48,6 +50,10 @@ export type RepoCoreActions = {
   addDeployment: (
     deployment: Omit<Deployment, 'deployedBy' | 'branch' | 'timestamp'>
   ) => Promise<Deployment | undefined>
+  addContributor: (address: string) => Promise<void>
+  acceptContributor: () => Promise<void>
+  rejectContributor: () => Promise<void>
+  grantAccessToContributor: () => Promise<void>
   fetchAndLoadRepository: (id: string, branchName?: string) => Promise<string>
   fetchAndLoadParentRepository: (repo: Repo) => Promise<void>
   fetchAndLoadForkRepository: (id: string) => Promise<void>

--- a/src/types/repository.ts
+++ b/src/types/repository.ts
@@ -1,5 +1,11 @@
 import { User } from './user'
 
+export type PrivateState = {
+  iv: string
+  keys: Record<string, string>
+  version: string
+}
+
 export type Repo = {
   id: string
   name: string
@@ -16,6 +22,8 @@ export type Repo = {
   fork: boolean
   parent: string | null
   timestamp: number
+  private: boolean
+  privateStateTxId?: string
 }
 
 export type ForkMetaData = Pick<Repo, 'id' | 'name' | 'owner' | 'timestamp'>

--- a/src/types/repository.ts
+++ b/src/types/repository.ts
@@ -2,8 +2,9 @@ import { User } from './user'
 
 export type PrivateState = {
   iv: string
-  keys: Record<string, string>
+  encKeys: Record<string, string>
   version: string
+  pubKeys: string[]
 }
 
 export type Repo = {

--- a/src/types/repository.ts
+++ b/src/types/repository.ts
@@ -24,7 +24,16 @@ export type Repo = {
   timestamp: number
   private: boolean
   privateStateTxId?: string
+  contributorInvites: ContributorInvite[]
 }
+
+export type ContributorInvite = {
+  address: string
+  timestamp: number
+  status: ContributorStatus
+}
+
+export type ContributorStatus = 'INVITED' | 'ACCEPTED' | 'REJECTED'
 
 export type ForkMetaData = Pick<Repo, 'id' | 'name' | 'owner' | 'timestamp'>
 

--- a/warp/protocol-land/actions/evolve.ts
+++ b/warp/protocol-land/actions/evolve.ts
@@ -1,4 +1,5 @@
-import { ContractResult, ContractState, EvolveAction, Repo } from '../types'
+import { ContractResult, ContractState, ContributorInvite, EvolveAction, Repo } from '../types'
+import { getBlockTimeStamp } from '../utils/getBlockTimeStamp'
 
 declare const ContractError
 
@@ -26,4 +27,42 @@ export function evolveRepoState(repoObj: Repo) {
   }
 
   return { ...defaultRepo, ...repoObj }
+}
+
+export async function postEvolve(
+  state: ContractState,
+  { caller }: EvolveAction
+): Promise<ContractResult<ContractState>> {
+  // validate owner
+  if (state.owner !== caller) {
+    throw new ContractError('Only the owner can evolve a contract.')
+  }
+
+  if (state.stateEvolve1) return { state }
+
+  for (const repoId in state.repos) {
+    const repo = state.repos[repoId]
+
+    if (!repo.contributorInvites) {
+      repo.contributorInvites = []
+    } else {
+      repo.contributors.forEach((contributor) => {
+        const inviteExists = repo.contributorInvites.find((invite) => invite.address === contributor)
+
+        if (!inviteExists) {
+          const invite: ContributorInvite = {
+            address: contributor,
+            timestamp: getBlockTimeStamp(),
+            status: 'ACCEPTED'
+          }
+
+          repo.contributorInvites.push(invite)
+        }
+      })
+    }
+  }
+
+  state.stateEvolve1 = true
+
+  return { state }
 }

--- a/warp/protocol-land/actions/repository.ts
+++ b/warp/protocol-land/actions/repository.ts
@@ -1,4 +1,5 @@
 import { ContractResult, ContractState, Deployment, Repo, RepositoryAction } from '../types'
+import { getBlockTimeStamp } from '../utils/getBlockTimeStamp'
 
 declare const ContractError, SmartWeave
 
@@ -41,10 +42,16 @@ export async function initializeNewRepository(
     deployments: [],
     issues: [],
     deploymentBranch: '',
-    timestamp: Date.now(),
+    timestamp: getBlockTimeStamp(),
     fork: false,
     forks: {},
-    parent: null
+    parent: null,
+    private: false
+  }
+
+  if (payload.visibility === 'private') {
+    repo.private = true
+    repo.privateStateTxId = payload.privateStateTxId
   }
 
   state.repos[repo.id] = repo
@@ -93,10 +100,11 @@ export async function forkRepository(
     issues: [],
     deployments: [],
     deploymentBranch: '',
-    timestamp: Date.now(),
+    timestamp: getBlockTimeStamp(),
     fork: true,
     forks: {},
-    parent: payload.parent
+    parent: payload.parent,
+    private: false
   }
 
   const parentRepo: Repo = state.repos[payload.parent]

--- a/warp/protocol-land/actions/repository.ts
+++ b/warp/protocol-land/actions/repository.ts
@@ -410,10 +410,12 @@ export async function rejectContributorInvite(
     throw new ContractError('Repository not found.')
   }
 
-  const contributorInviteIdx = repo.contributorInvites.findIndex((invite) => invite.address === caller)
+  const contributorInviteIdx = repo.contributorInvites.findIndex(
+    (invite) => invite.address === caller && invite.status === 'INVITED'
+  )
 
   if (contributorInviteIdx < 0) {
-    throw new ContractError('Error: No invite was found to contribute.')
+    throw new ContractError('Error: No invite was found to reject.')
   }
 
   const contributorExists = repo.contributors.findIndex((address) => address === caller)

--- a/warp/protocol-land/contract.ts
+++ b/warp/protocol-land/contract.ts
@@ -27,6 +27,7 @@ import {
   inviteContributor,
   isRepositoryNameAvailable,
   rejectContributorInvite,
+  updatePrivateStateTx,
   updateRepositoryDetails,
   updateRepositoryTxId
 } from './actions/repository'
@@ -65,6 +66,8 @@ export async function handle(state: ContractState, action: RepositoryAction | Ev
       return await acceptContributorInvite(state, action as RepositoryAction)
     case 'rejectContributorInvite':
       return await rejectContributorInvite(state, action as RepositoryAction)
+    case 'updatePrivateStateTx':
+      return await updatePrivateStateTx(state, action as RepositoryAction)
     case 'createPullRequest':
       return await createNewPullRequest(state, action as RepositoryAction)
     case 'updatePullRequestStatus':

--- a/warp/protocol-land/contract.ts
+++ b/warp/protocol-land/contract.ts
@@ -19,6 +19,7 @@ import {
   acceptContributorInvite,
   addContributor,
   addDeployment,
+  cancelContributorInvite,
   forkRepository,
   getAllRepositoriesByContributor,
   getAllRepositoriesByOwner,
@@ -66,6 +67,8 @@ export async function handle(state: ContractState, action: RepositoryAction | Ev
       return await acceptContributorInvite(state, action as RepositoryAction)
     case 'rejectContributorInvite':
       return await rejectContributorInvite(state, action as RepositoryAction)
+    case 'cancelContributorInvite':
+      return await cancelContributorInvite(state, action as RepositoryAction)
     case 'updatePrivateStateTx':
       return await updatePrivateStateTx(state, action as RepositoryAction)
     case 'createPullRequest':

--- a/warp/protocol-land/contract.ts
+++ b/warp/protocol-land/contract.ts
@@ -1,4 +1,4 @@
-import { evolveContract } from './actions/evolve'
+import { evolveContract, postEvolve } from './actions/evolve'
 import {
   addAssigneeToIssue,
   addCommentToIssue,
@@ -16,6 +16,7 @@ import {
   updatePullRequestStatus
 } from './actions/pull-requests'
 import {
+  acceptContributorInvite,
   addContributor,
   addDeployment,
   forkRepository,
@@ -23,7 +24,9 @@ import {
   getAllRepositoriesByOwner,
   getRepository,
   initializeNewRepository,
+  inviteContributor,
   isRepositoryNameAvailable,
+  rejectContributorInvite,
   updateRepositoryDetails,
   updateRepositoryTxId
 } from './actions/repository'
@@ -56,6 +59,12 @@ export async function handle(state: ContractState, action: RepositoryAction | Ev
       return await addDeployment(state, action as RepositoryAction)
     case 'addContributor':
       return await addContributor(state, action as RepositoryAction)
+    case 'inviteContributor':
+      return await inviteContributor(state, action as RepositoryAction)
+    case 'acceptContributorInvite':
+      return await acceptContributorInvite(state, action as RepositoryAction)
+    case 'rejectContributorInvite':
+      return await rejectContributorInvite(state, action as RepositoryAction)
     case 'createPullRequest':
       return await createNewPullRequest(state, action as RepositoryAction)
     case 'updatePullRequestStatus':
@@ -86,6 +95,8 @@ export async function handle(state: ContractState, action: RepositoryAction | Ev
       return await getUserDetails(state, action as RepositoryAction)
     case 'evolve':
       return await evolveContract(state, action as EvolveAction)
+    case 'postEvolve':
+      return await postEvolve(state, action as EvolveAction)
     default:
       throw new ContractError(`No function supplied or function not recognised`)
   }

--- a/warp/protocol-land/types/index.ts
+++ b/warp/protocol-land/types/index.ts
@@ -195,7 +195,8 @@ const repoFnList = [
   'updateProfileDetails',
   'getUserDetails',
   'postEvolve',
-  'updatePrivateStateTx'
+  'updatePrivateStateTx',
+  'cancelContributorInvite'
 ] as const
 
 export type RepositoryFunction = (typeof repoFnList)[number] // more types will be added later

--- a/warp/protocol-land/types/index.ts
+++ b/warp/protocol-land/types/index.ts
@@ -5,6 +5,7 @@ export type ContractState = {
   canEvolve: boolean
   evolve: null | any
   owner: Address
+  stateEvolve1: boolean
 }
 
 export type User = {
@@ -50,7 +51,16 @@ export type Repo = {
   parent: string | null
   private: boolean
   privateStateTxId?: string
+  contributorInvites: ContributorInvite[]
 }
+
+export type ContributorInvite = {
+  address: string
+  timestamp: number
+  status: ContributorStatus
+}
+
+export type ContributorStatus = 'INVITED' | 'ACCEPTED' | 'REJECTED'
 
 export type Forks = Record<Address, Pick<Repo, 'id' | 'name' | 'owner' | 'timestamp'>>
 
@@ -170,6 +180,9 @@ const repoFnList = [
   'updateRepositoryDetails',
   'addDeployment',
   'addContributor',
+  'inviteContributor',
+  'acceptContributorInvite',
+  'rejectContributorInvite',
   'addReviewersToPR',
   'approvePR',
   'createIssue',
@@ -180,7 +193,8 @@ const repoFnList = [
   'createNewBounty',
   'updateBounty',
   'updateProfileDetails',
-  'getUserDetails'
+  'getUserDetails',
+  'postEvolve'
 ] as const
 
 export type RepositoryFunction = (typeof repoFnList)[number] // more types will be added later

--- a/warp/protocol-land/types/index.ts
+++ b/warp/protocol-land/types/index.ts
@@ -48,6 +48,8 @@ export type Repo = {
   forks: Forks
   fork: boolean
   parent: string | null
+  private: boolean
+  privateStateTxId?: string
 }
 
 export type Forks = Record<Address, Pick<Repo, 'id' | 'name' | 'owner' | 'timestamp'>>

--- a/warp/protocol-land/types/index.ts
+++ b/warp/protocol-land/types/index.ts
@@ -194,7 +194,8 @@ const repoFnList = [
   'updateBounty',
   'updateProfileDetails',
   'getUserDetails',
-  'postEvolve'
+  'postEvolve',
+  'updatePrivateStateTx'
 ] as const
 
 export type RepositoryFunction = (typeof repoFnList)[number] // more types will be added later

--- a/warp/protocol-land/utils/getBlockTimeStamp.ts
+++ b/warp/protocol-land/utils/getBlockTimeStamp.ts
@@ -1,0 +1,5 @@
+declare const SmartWeave
+
+export function getBlockTimeStamp() {
+  return 1000 * +SmartWeave.block.timestamp
+}


### PR DESCRIPTION
## Summary
This feature implements logic to support private repositories on protocol.land. 

We create a new AES key(Symmetric) to encrypt repo, then encrypt AES key itself with PubKey of all necessary contributors starting with owner. and encrypted keys are stored on arweave. When a valid contributor tries to access repo, we decrypt the AES key with their PrivateKey and further decrypt the repo with AES key.

