### PR TITLE
fix: Update file viewer & editor to display long content files

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -9,9 +9,15 @@
   list-style: revert;
 }
 
-.w-md-editor-toolbar {
+#file-view-editor .w-md-editor-toolbar {
   position: sticky;
   top: 92px;
+  z-index: 10;
+}
+
+#new-file-editor .w-md-editor-toolbar {
+  position: sticky;
+  top: 96px;
   z-index: 10;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,12 @@
   list-style: revert;
 }
 
+.w-md-editor-toolbar {
+  position: sticky;
+  top: 92px;
+  z-index: 10;
+}
+
 .cm-theme .cm-editor {
   height: 100% !important;
 }

--- a/src/pages/repository/components/tabs/code-tab/FileView.tsx
+++ b/src/pages/repository/components/tabs/code-tab/FileView.tsx
@@ -76,7 +76,7 @@ export default function FileView({ fileContent, setFileContent, filename, setFil
   }
 
   return (
-    <div className="flex flex-col w-full h-full">
+    <div className="flex flex-col w-full h-full" id="file-view-editor">
       <Sticky top={0} innerActiveClass="z-20" onStateChange={handleStateChange}>
         <div className={clsx('flex gap-2 flex-col bg-gray-50', isSticky && 'pt-2')}>
           <div className="flex w-full justify-between h-10">

--- a/src/pages/repository/components/tabs/code-tab/NewFile.tsx
+++ b/src/pages/repository/components/tabs/code-tab/NewFile.tsx
@@ -9,6 +9,7 @@ import { FileWithPath } from 'react-dropzone'
 import toast from 'react-hot-toast'
 import { FiArrowLeft } from 'react-icons/fi'
 import { useNavigate } from 'react-router-dom'
+import Sticky from 'react-stickynode'
 
 import { Button } from '@/components/common/buttons'
 import { rootTabConfig } from '@/pages/repository/config/rootTabConfig'
@@ -21,6 +22,7 @@ export default function NewFile() {
   const [fileContent, setFileContent] = React.useState('')
   const [filename, setFilename] = React.useState('')
   const [files, setFiles] = React.useState<FileWithPath[]>([])
+  const [isSticky, setIsSticky] = React.useState(false)
   const [isCommitModalOpen, setIsCommitModalOpen] = React.useState(false)
   const [isSubmitting, setIsSubmitting] = React.useState(false)
   const [isFileCommited, setIsFileCommitted] = React.useState(false)
@@ -92,63 +94,78 @@ export default function NewFile() {
     }
   }
 
+  const handleStateChange = (status: Sticky.Status) => {
+    setIsSticky(status.status === Sticky.STATUS_FIXED)
+  }
+
   return (
-    <div className="flex flex-col gap-2 w-full h-full">
-      <div className="flex w-full justify-between h-10">
-        <div className="flex gap-3">
-          <Button onClick={onGoBackClick} className="gap-2 font-medium" variant="primary-outline">
-            <FiArrowLeft className="w-5 h-5 text-[inherit]" /> Go back
-          </Button>
-          <div className="flex items-center gap-1">
-            <span>{getBasePath()}</span>
-            <input
-              type="text"
-              placeholder="Name your file..."
-              value={filename}
-              onChange={(e) => setFilename(e.target.value)}
-              className="bg-white border-[1px] text-gray-900 text-base rounded-lg hover:shadow-[0px_2px_4px_0px_rgba(0,0,0,0.10)] focus:border-primary-500 focus:border-[1.5px] block w-full px-3 py-1 outline-none border-gray-300"
-            />
-            <span>in</span>{' '}
-            <span
-              onClick={gotoBranch}
-              className="bg-primary-200 px-1 rounded-md text-primary-700 hover:underline cursor-pointer"
-            >
-              {currentBranch}
-            </span>
+    <div className="flex flex-col w-full h-full" id="new-file-editor">
+      <Sticky top={0} innerActiveClass="z-10" onStateChange={handleStateChange}>
+        <div className={clsx('flex flex-col gap-3 bg-gray-50', isSticky && 'pt-2')}>
+          <div className="flex w-full justify-between h-10">
+            <div className="flex gap-3">
+              <Button onClick={onGoBackClick} className="gap-2 font-medium" variant="primary-outline">
+                <FiArrowLeft className="w-5 h-5 text-[inherit]" /> Go back
+              </Button>
+              <div className="flex items-center gap-1">
+                <span>{getBasePath()}</span>
+                <input
+                  type="text"
+                  placeholder="Name your file..."
+                  value={filename}
+                  onChange={(e) => setFilename(e.target.value)}
+                  className="bg-white border-[1px] text-gray-900 text-base rounded-lg hover:shadow-[0px_2px_4px_0px_rgba(0,0,0,0.10)] focus:border-primary-500 focus:border-[1.5px] block w-full px-3 py-1 outline-none border-gray-300"
+                />
+                <span>in</span>{' '}
+                <span
+                  onClick={gotoBranch}
+                  className="bg-primary-200 px-1 rounded-md text-primary-700 hover:underline cursor-pointer"
+                >
+                  {currentBranch}
+                </span>
+              </div>
+            </div>
+            {contributor && (
+              <div className="flex gap-2">
+                <Button onClick={onGoBackClick} variant="primary-outline">
+                  Cancel changes
+                </Button>
+                <Button
+                  isLoading={isSubmitting}
+                  onClick={handleCommitChangesClick}
+                  variant="primary-solid"
+                  disabled={!filename}
+                >
+                  Commit changes
+                </Button>
+                <CommitFilesModal
+                  setIsCommited={setIsFileCommitted}
+                  setIsOpen={setIsCommitModalOpen}
+                  isOpen={isCommitModalOpen}
+                  files={files}
+                />
+              </div>
+            )}
+          </div>
+          <div className="w-full flex flex-col border-gray-300 border-[1px] rounded-lg rounded-b-none border-b-0 bg-white">
+            <div className="rounded-t-lg flex justify-between bg-gray-200 border-b-[1px] border-gray-300 items-center gap-2 py-2 px-4 text-gray-900 font-medium h-10">
+              <span className={clsx(!filename && 'py-10')}>{filename}</span>
+            </div>
           </div>
         </div>
-        {contributor && (
-          <div className="flex gap-2">
-            <Button onClick={onGoBackClick} variant="primary-outline">
-              Cancel changes
-            </Button>
-            <Button
-              isLoading={isSubmitting}
-              onClick={handleCommitChangesClick}
-              variant="primary-solid"
-              disabled={!filename}
-            >
-              Commit changes
-            </Button>
-            <CommitFilesModal
-              setIsCommited={setIsFileCommitted}
-              setIsOpen={setIsCommitModalOpen}
-              isOpen={isCommitModalOpen}
-              files={files}
-            />
-          </div>
-        )}
-      </div>
+      </Sticky>
       <div className="flex w-full h-full mb-4">
-        <div className="w-full flex flex-col border-gray-300 border-[1px] rounded-lg bg-white overflow-hidden">
-          <div className="rounded-t-lg flex justify-between bg-gray-200 border-b-[1px] border-gray-300 items-center gap-2 py-2 px-4 text-gray-900 font-medium h-10">
-            <span className={clsx(!filename && 'py-10')}>{filename}</span>
-          </div>
+        <div className="w-full flex flex-col border-gray-300 border-[1px] rounded-t-none border-t-0 rounded-lg bg-white">
           {isMarkdownFile ? (
-            <MDEditor minHeight={200} preview="edit" value={fileContent} onChange={(value) => setFileContent(value!)} />
+            <MDEditor
+              className="!h-full !min-h-[200px]"
+              visibleDragbar={false}
+              value={fileContent}
+              onChange={(value) => setFileContent(value!)}
+            />
           ) : (
             <CodeMirror
-              className="min-h-[100%] w-full"
+              className="w-full h-full rounded-b-lg overflow-hidden"
               value={fileContent}
               minHeight="200px"
               height="100%"

--- a/src/pages/repository/components/tabs/code-tab/Readme.tsx
+++ b/src/pages/repository/components/tabs/code-tab/Readme.tsx
@@ -1,0 +1,46 @@
+import MDEditor from '@uiw/react-md-editor'
+import React, { useEffect } from 'react'
+import { LiaReadme } from 'react-icons/lia'
+
+import { getFileContent } from '@/pages/repository/helpers/filenameHelper'
+import { useGlobalStore } from '@/stores/globalStore'
+import { FileObject } from '@/stores/repository-core/types'
+
+export default function Readme({ fileObject }: { fileObject?: FileObject }) {
+  const [fileContent, setFileContent] = React.useState('')
+  const [isLoading, setIsLoading] = React.useState(false)
+  const [gitActions] = useGlobalStore((state) => [state.repoCoreActions.git])
+
+  useEffect(() => {
+    loadReadmeContent()
+  }, [fileObject])
+
+  async function loadReadmeContent() {
+    setIsLoading(true)
+    if (!fileObject || !fileObject.oid) {
+      setIsLoading(false)
+      return
+    }
+
+    const blob = await gitActions.readFileContentFromOid(fileObject.oid)
+
+    if (!blob) return
+
+    const fileContent = (await getFileContent(blob, fileObject.path)) || ''
+
+    setFileContent(fileContent)
+    setIsLoading(false)
+  }
+
+  if (!fileObject) return null
+
+  return (
+    <div className="border border-gray-300 rounded-lg">
+      <div className="sticky -top-1 z-10 h-12 flex items-center gap-2 bg-gray-200 border-gray-300 border-b rounded-t-lg px-4">
+        <LiaReadme className="w-5 h-5" />
+        <div className="font-medium">README</div>
+      </div>
+      <MDEditor.Markdown className="p-8 !min-h-[200px] rounded-b-lg" source={isLoading ? 'Loading...' : fileContent} />
+    </div>
+  )
+}

--- a/src/pages/repository/components/tabs/code-tab/index.tsx
+++ b/src/pages/repository/components/tabs/code-tab/index.tsx
@@ -29,7 +29,7 @@ export default function CodeTab({ repoName = '', id = '' }: Props) {
   ])
   const readmeFileObject = React.useMemo(
     () => git.fileObjects.find((file) => file.path.toLowerCase() === 'readme.md'),
-    [git.currentOid]
+    [git.fileObjects]
   )
   const [fileContent, setFileContent] = React.useState({ original: '', modified: '' })
   const [filename, setFilename] = React.useState('')

--- a/src/pages/repository/components/tabs/code-tab/index.tsx
+++ b/src/pages/repository/components/tabs/code-tab/index.tsx
@@ -9,6 +9,7 @@ import { useGlobalStore } from '@/stores/globalStore'
 import FileView from './FileView'
 import Header from './header/Header'
 import NewFile from './NewFile'
+import Readme from './Readme'
 import RepoError from './RepoError'
 import RepoLoading from './RepoLoading'
 import Row from './Row'
@@ -26,6 +27,10 @@ export default function CodeTab({ repoName = '', id = '' }: Props) {
     state.repoCoreActions.git,
     state.branchState.currentBranch
   ])
+  const readmeFileObject = React.useMemo(
+    () => git.fileObjects.find((file) => file.path.toLowerCase() === 'readme.md'),
+    [git.currentOid]
+  )
   const [fileContent, setFileContent] = React.useState({ original: '', modified: '' })
   const [filename, setFilename] = React.useState('')
   const [filePath, setFilePath] = React.useState('')
@@ -102,35 +107,38 @@ export default function CodeTab({ repoName = '', id = '' }: Props) {
   }
 
   return (
-    <div className="flex flex-col gap-6 w-full">
-      <Header />
-      <div className="flex w-full">
-        <div className="border-gray-300 border-[1px] w-full rounded-lg bg-white overflow-hidden">
-          <TableHead commit={repoCommitsG[0]} />
-          {!git.fileObjects.length && (
-            <div className="py-6 flex gap-2 justify-center items-center">
-              <FiCode className="w-8 h-8 text-liberty-dark-100" />
-              <h1 className="text-lg text-liberty-dark-100">Get started by adding some files</h1>
-            </div>
-          )}
-          {git.rootOid !== git.currentOid && (
-            <div
-              onClick={gitActions.goBack}
-              className="flex cursor-pointer hover:bg-liberty-light-300 items-center gap-2 py-2 px-4 border-b-[1px] border-liberty-light-600"
-            >
-              <span>...</span>
-            </div>
-          )}
-          {git.fileObjects.map((file: any) => (
-            <Row
-              onFolderClick={handleFolderClick}
-              onFileClick={handleFileClick}
-              item={file}
-              isFolder={file.type === 'folder'}
-            />
-          ))}
+    <div className="flex flex-col gap-4 w-full">
+      <div className="flex flex-col gap-6 w-full">
+        <Header />
+        <div className="flex w-full">
+          <div className="border-gray-300 border-[1px] w-full rounded-lg bg-white overflow-hidden">
+            <TableHead commit={repoCommitsG[0]} />
+            {!git.fileObjects.length && (
+              <div className="py-6 flex gap-2 justify-center items-center">
+                <FiCode className="w-8 h-8 text-liberty-dark-100" />
+                <h1 className="text-lg text-liberty-dark-100">Get started by adding some files</h1>
+              </div>
+            )}
+            {git.rootOid !== git.currentOid && (
+              <div
+                onClick={gitActions.goBack}
+                className="flex cursor-pointer hover:bg-liberty-light-300 items-center gap-2 py-2 px-4 border-b-[1px] border-liberty-light-600"
+              >
+                <span>...</span>
+              </div>
+            )}
+            {git.fileObjects.map((file: any) => (
+              <Row
+                onFolderClick={handleFolderClick}
+                onFileClick={handleFileClick}
+                item={file}
+                isFolder={file.type === 'folder'}
+              />
+            ))}
+          </div>
         </div>
       </div>
+      <Readme fileObject={readmeFileObject} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

This PR adds improvements to current file viewer & editor to display the long content files properly with scroll. Also, this PR displays README.md file below the repo files explorer if present in a directory.

- README
    ![image](https://github.com/labscommunity/protocol-land/assets/11836100/6077edfd-bf01-4c0c-8a34-ef2068f645e9)

- Editing a long content file with file editor header stick to top
    ![image](https://github.com/labscommunity/protocol-land/assets/11836100/a00dff87-5a82-43a7-bc03-09cfbf9d9447)

- Previewing a long content file with file viewer header stick to top 
![image](https://github.com/labscommunity/protocol-land/assets/11836100/3651566c-46b8-486a-8f9e-beed0fbd8c54)

- Creating a new file with long content with file editor header stick to top
![image](https://github.com/labscommunity/protocol-land/assets/11836100/cf0463ce-16f7-4290-9782-0f31cf3c891c)


