### PR TITLE
fix: Rename userName & fullName to correct names

### DIFF
--- a/warp/protocol-land/actions/user.ts
+++ b/warp/protocol-land/actions/user.ts
@@ -22,8 +22,8 @@ export async function updateProfileDetails(
   // Validate each property of the payload against its expected type
   if (
     isInvalidInput(payload, 'object') ||
-    (payload.fullName !== undefined && isInvalidInput(payload.fullName, 'string', true)) ||
-    (payload.userName !== undefined && isInvalidInput(payload.userName, 'string', true)) ||
+    (payload.fullname !== undefined && isInvalidInput(payload.fullname, 'string', true)) ||
+    (payload.username !== undefined && isInvalidInput(payload.username, 'string', true)) ||
     (payload.avatar !== undefined && isInvalidInput(payload.avatar, 'arweave-address')) ||
     (payload.bio !== undefined && isInvalidInput(payload.bio, 'string', true)) ||
     (payload.timezone !== undefined && isInvalidTimezone(payload.timezone)) ||
@@ -38,8 +38,8 @@ export async function updateProfileDetails(
 
   // Filter the payload to only include allowed keys
   const filteredPayload = pickKeys(payload, [
-    'fullName',
-    'userName',
+    'fullname',
+    'username',
     'avatar',
     'bio',
     'timezone',

--- a/warp/protocol-land/types/index.ts
+++ b/warp/protocol-land/types/index.ts
@@ -8,8 +8,8 @@ export type ContractState = {
 }
 
 export type User = {
-  fullName?: string
-  userName?: string
+  fullname?: string
+  username?: string
   avatar?: string
   bio?: string
   timezone?: Timezone


### PR DESCRIPTION
## Summary

This PR renames `userName` & `fullName` to `username` & `fullname` which is used in the PL app to fix username and fullname not updating issue. The User type in contract had `userName` and `fullName` so same name was used in the contract but `username` and `fullname` was used on PL app.