### PR TITLE
feat: Display username over address in explore page

### DIFF
--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -70,8 +70,8 @@ export default function Home() {
       <div className="h-full flex flex-1">
         <Sidebar repos={userRepos} isLoading={fetchUserReposStatus === 'PENDING'} setIsRepoModalOpen={setIsOpen} />
         <MainContent>
-          <div className="w-[70%] lg:w-[85%] xl:w-[80%] 2xl:w-[70%] py-8 flex flex-col gap-8">
-            <div className="flex gap-8 w-full">
+          <div className="lg:w-[85%] xl:w-[80%] 2xl:w-[70%] py-8 flex flex-col gap-8">
+            <div className="flex flex-col md:flex-row gap-8 w-full">
               <div
                 className={
                   'bg-primary-100 p-6 min-h-[200px] w-full flex flex-col items-center gap-4 justify-center rounded-2xl border-[1px] border-primary-200'

--- a/src/pages/home/components/ActivityHeader.tsx
+++ b/src/pages/home/components/ActivityHeader.tsx
@@ -25,7 +25,7 @@ export default function ActivityHeader({ activity, setIsForkModalOpen, setRepo }
             {activity.repo.name}
           </Link>
         </div>
-        <div className="bg-gray-200 border text-sm px-2 rounded-md">
+        <div className="bg-gray-200 border text-sm px-2 rounded-md truncate">
           Owner:{' '}
           <Link
             className="font-normal hover:underline text-primary-600 hover:text-primary-700 cursor-pointer"

--- a/src/pages/home/components/ActivityHeader.tsx
+++ b/src/pages/home/components/ActivityHeader.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction } from 'react'
 import { Link } from 'react-router-dom'
 
-import { shortenAddress } from '@/helpers/shortenAddress'
+import { resolveUsernameOrShorten } from '@/helpers/resolveUsername'
 import { Activity } from '@/types/explore'
 import { Repo } from '@/types/repository'
 
@@ -31,7 +31,7 @@ export default function ActivityHeader({ activity, setIsForkModalOpen, setRepo }
             className="font-normal hover:underline text-primary-600 hover:text-primary-700 cursor-pointer"
             to={`/user/${activity.repo.owner}`}
           >
-            {shortenAddress(activity.repo.owner)}
+            {resolveUsernameOrShorten(activity.repo.owner)}
           </Link>
         </div>
       </div>

--- a/src/pages/home/components/ActivityHeader.tsx
+++ b/src/pages/home/components/ActivityHeader.tsx
@@ -15,7 +15,7 @@ interface ActivityHeaderProps {
 
 export default function ActivityHeader({ activity, setIsForkModalOpen, setRepo }: ActivityHeaderProps) {
   return (
-    <div className="w-full flex justify-between items-center">
+    <div className="w-full flex justify-between items-center gap-2">
       <div className="flex items-center gap-3">
         <div className="flex items-center">
           <Link
@@ -25,7 +25,7 @@ export default function ActivityHeader({ activity, setIsForkModalOpen, setRepo }
             {activity.repo.name}
           </Link>
         </div>
-        <div className="bg-gray-200 border text-sm px-2 rounded-md truncate">
+        <div className="border-primary-500 border text-sm px-2 rounded-md truncate">
           Owner:{' '}
           <Link
             className="font-normal hover:underline text-primary-600 hover:text-primary-700 cursor-pointer"

--- a/src/pages/home/components/BountyActivity.tsx
+++ b/src/pages/home/components/BountyActivity.tsx
@@ -34,7 +34,7 @@ export default function BountyActivity({ activity, setIsForkModalOpen, setRepo }
           <>{activity.bounty?.amount ?? ''} AR</>
         </Link>
         <div className="text-sm">{activity.issue?.title ?? ''} AR</div>
-        <div className="flex gap-3 text-sm items-center justify-between">
+        <div className="flex gap-1 text-sm items-center justify-between flex-wrap">
           <div className="flex items-center gap-1">
             <Icon />
             <span>

--- a/src/pages/home/components/DeploymentActivity.tsx
+++ b/src/pages/home/components/DeploymentActivity.tsx
@@ -1,7 +1,7 @@
 import { formatDistanceToNow } from 'date-fns'
 import { Link } from 'react-router-dom'
 
-import { shortenAddress } from '@/helpers/shortenAddress'
+import { resolveUsernameOrShorten } from '@/helpers/resolveUsername'
 import { ActivityProps, DeploymentActivityType } from '@/types/explore'
 
 import ActivityHeader from './ActivityHeader'
@@ -27,7 +27,7 @@ export default function DeploymentActivity({
           <span>
             Deployment done by{' '}
             <Link className="text-primary-600 hover:text-primary-700" to={`/user/${deployment.deployedBy}`}>
-              {shortenAddress(deployment.deployedBy)}
+              {resolveUsernameOrShorten(deployment.deployedBy)}
             </Link>{' '}
             {formatDistanceToNow(new Date(activity.timestamp * 1000), { addSuffix: true })}
           </span>

--- a/src/pages/home/components/DeploymentActivity.tsx
+++ b/src/pages/home/components/DeploymentActivity.tsx
@@ -23,7 +23,7 @@ export default function DeploymentActivity({
           {deployment.commitMessage}
         </Link>
 
-        <div className="flex items-center gap-3 text-sm justify-between">
+        <div className="flex items-center gap-1 text-sm justify-between flex-wrap">
           <span>
             Deployment done by{' '}
             <Link className="text-primary-600 hover:text-primary-700" to={`/user/${deployment.deployedBy}`}>

--- a/src/pages/home/components/DomainActivity.tsx
+++ b/src/pages/home/components/DomainActivity.tsx
@@ -1,7 +1,7 @@
 import { formatDistanceToNow } from 'date-fns'
 import { Link } from 'react-router-dom'
 
-import { shortenAddress } from '@/helpers/shortenAddress'
+import { resolveUsernameOrShorten } from '@/helpers/resolveUsername'
 import { ActivityProps, DomainActivityType } from '@/types/explore'
 
 import ActivityHeader from './ActivityHeader'
@@ -22,7 +22,7 @@ export default function DomainActivity({ activity, setIsForkModalOpen, setRepo }
           <span>
             ArNS Domain {activity.created ? 'added' : 'updated'} by{' '}
             <Link className="text-primary-600 hover:text-primary-700" to={`/user/${domain.controller}`}>
-              {shortenAddress(domain.controller)}
+              {resolveUsernameOrShorten(domain.controller)}
             </Link>{' '}
             {formatDistanceToNow(new Date(activity.timestamp * 1000), { addSuffix: true })}
           </span>

--- a/src/pages/home/components/DomainActivity.tsx
+++ b/src/pages/home/components/DomainActivity.tsx
@@ -18,7 +18,7 @@ export default function DomainActivity({ activity, setIsForkModalOpen, setRepo }
           {domain.name}
         </Link>
 
-        <div className="flex items-center gap-3 text-sm justify-between">
+        <div className="flex items-center gap-1 text-sm justify-between flex-wrap">
           <span>
             ArNS Domain {activity.created ? 'added' : 'updated'} by{' '}
             <Link className="text-primary-600 hover:text-primary-700" to={`/user/${domain.controller}`}>

--- a/src/pages/home/components/IssueActivity.tsx
+++ b/src/pages/home/components/IssueActivity.tsx
@@ -26,9 +26,9 @@ export default function IssueActivity({ activity, setIsForkModalOpen, setRepo }:
         </Link>
         <div className="flex gap-1 flex-shrink-0 items-center text-sm justify-between flex-wrap">
           <div className="flex gap-1 items-center">
-            <div className={clsx('h-2 w-2 rounded-full', isOpen ? 'bg-[#38a457]' : 'bg-purple-700')}></div>
+            <div className={clsx('px-2 rounded-full text-white', isOpen ? 'bg-green-700' : 'bg-purple-700')}>Issue</div>
             <div>
-              Issue {isOpen ? <span>{activity.created ? 'opened ' : 'reopened '}</span> : <span>was closed </span>}
+              {isOpen ? <span>{activity.created ? 'opened ' : 'reopened '}</span> : <span>was closed </span>}
               <span>
                 by{' '}
                 <Link className="text-primary-600 hover:text-primary-700" to={`/user/${issue.author}`}>

--- a/src/pages/home/components/IssueActivity.tsx
+++ b/src/pages/home/components/IssueActivity.tsx
@@ -24,7 +24,7 @@ export default function IssueActivity({ activity, setIsForkModalOpen, setRepo }:
           <span>{issue?.title ?? ''}</span>
           {issue?.id && <span className="text-gray-400">#{issue?.id}</span>}
         </Link>
-        <div className="flex gap-3 flex-shrink-0 items-center text-sm justify-between">
+        <div className="flex gap-1 flex-shrink-0 items-center text-sm justify-between flex-wrap">
           <div className="flex gap-1 items-center">
             <div className={clsx('h-2 w-2 rounded-full', isOpen ? 'bg-[#38a457]' : 'bg-purple-700')}></div>
             <div>

--- a/src/pages/home/components/IssueActivity.tsx
+++ b/src/pages/home/components/IssueActivity.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { formatDistanceToNow } from 'date-fns'
 import { Link } from 'react-router-dom'
 
-import { shortenAddress } from '@/helpers/shortenAddress'
+import { resolveUsernameOrShorten } from '@/helpers/resolveUsername'
 import { ActivityProps, IssueActivityType } from '@/types/explore'
 
 import ActivityHeader from './ActivityHeader'
@@ -32,7 +32,7 @@ export default function IssueActivity({ activity, setIsForkModalOpen, setRepo }:
               <span>
                 by{' '}
                 <Link className="text-primary-600 hover:text-primary-700" to={`/user/${issue.author}`}>
-                  {shortenAddress(issue.author)}{' '}
+                  {resolveUsernameOrShorten(issue.author)}{' '}
                 </Link>
               </span>
               {isOpen && issue.timestamp && (

--- a/src/pages/home/components/IssueActivity.tsx
+++ b/src/pages/home/components/IssueActivity.tsx
@@ -28,7 +28,7 @@ export default function IssueActivity({ activity, setIsForkModalOpen, setRepo }:
           <div className="flex gap-1 items-center">
             <div className={clsx('h-2 w-2 rounded-full', isOpen ? 'bg-[#38a457]' : 'bg-purple-700')}></div>
             <div>
-              Issue {isOpen ? <span>{activity.created ? 'opened ' : 'reopened '}</span> : <span>was closed</span>}
+              Issue {isOpen ? <span>{activity.created ? 'opened ' : 'reopened '}</span> : <span>was closed </span>}
               <span>
                 by{' '}
                 <Link className="text-primary-600 hover:text-primary-700" to={`/user/${issue.author}`}>

--- a/src/pages/home/components/PullRequestActivity.tsx
+++ b/src/pages/home/components/PullRequestActivity.tsx
@@ -27,8 +27,8 @@ export default function PullRequestActivity({
           <span>{pullRequest?.title ?? ''}</span>
           {pullRequest?.id && <span className="text-gray-400">#{pullRequest?.id}</span>}
         </Link>
-        <div className="flex gap-3 flex-shrink-0 items-center text-sm justify-between">
-          <div className="flex gap-1 items-center">
+        <div className="flex gap-1 flex-shrink-0 items-center text-sm justify-between flex-wrap">
+          <div className="flex gap-1 flex-wrap items-center">
             <div
               className={clsx(
                 'h-2 w-2 rounded-full',

--- a/src/pages/home/components/PullRequestActivity.tsx
+++ b/src/pages/home/components/PullRequestActivity.tsx
@@ -31,15 +31,16 @@ export default function PullRequestActivity({
           <div className="flex gap-1 flex-wrap items-center">
             <div
               className={clsx(
-                'h-2 w-2 rounded-full',
+                'px-2 rounded-full text-white',
                 pullRequest.status === 'OPEN'
                   ? 'bg-green-700'
                   : pullRequest.status === 'CLOSED'
                   ? 'bg-red-700'
                   : 'bg-purple-700'
               )}
-            ></div>
-            Pull Request
+            >
+              Pull Request
+            </div>
             <span>
               {pullRequest.status === 'OPEN'
                 ? activity.created

--- a/src/pages/home/components/PullRequestActivity.tsx
+++ b/src/pages/home/components/PullRequestActivity.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import { formatDistanceToNow } from 'date-fns'
 import { Link } from 'react-router-dom'
 
-import { shortenAddress } from '@/helpers/shortenAddress'
+import { resolveUsernameOrShorten } from '@/helpers/resolveUsername'
 import { ActivityProps, PullRequestActivityType } from '@/types/explore'
 
 import ActivityHeader from './ActivityHeader'
@@ -48,7 +48,7 @@ export default function PullRequestActivity({
                 : pullRequest.status.toLowerCase()}{' '}
               by{' '}
               <Link className="text-primary-600 hover:text-primary-700" to={`/user/${pullRequest.author}`}>
-                {shortenAddress(pullRequest.author)}
+                {resolveUsernameOrShorten(pullRequest.author)}
               </Link>
             </span>
             {pullRequest.status !== 'MERGED' && pullRequest.timestamp && (

--- a/src/pages/home/components/RepositoryActivity.tsx
+++ b/src/pages/home/components/RepositoryActivity.tsx
@@ -29,7 +29,7 @@ export default function RepositoryActivity({
         <ActivityHeader activity={activity} setIsForkModalOpen={setIsForkModalOpen} setRepo={setRepo} />
 
         <div className="text-sm">{activity.repo.description}</div>
-        <div className="flex gap-3 items-center text-sm justify-between">
+        <div className="flex gap-1 items-center flex-wrap text-sm justify-between">
           <span>
             {activity.created ? (activity.repo.fork ? 'Forked' : 'Created') : 'Updated'} by{' '}
             <Link className="text-primary-600 hover:text-primary-70" to={`/user/${activity.author}`}>

--- a/src/pages/home/components/RepositoryActivity.tsx
+++ b/src/pages/home/components/RepositoryActivity.tsx
@@ -2,7 +2,7 @@ import { formatDistanceToNow } from 'date-fns'
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 
-import { shortenAddress } from '@/helpers/shortenAddress'
+import { resolveUsernameOrShorten } from '@/helpers/resolveUsername'
 import { ActivityProps, RepositoryActivityType } from '@/types/explore'
 
 import { getRepoContributionsCount } from '../utils'
@@ -33,7 +33,7 @@ export default function RepositoryActivity({
           <span>
             {activity.created ? (activity.repo.fork ? 'Forked' : 'Created') : 'Updated'} by{' '}
             <Link className="text-primary-600 hover:text-primary-70" to={`/user/${activity.author}`}>
-              {shortenAddress(activity.author)}
+              {resolveUsernameOrShorten(activity.author)}
             </Link>{' '}
             {formatDistanceToNow(new Date(activity.timestamp * 1000), { addSuffix: true })}
           </span>


### PR DESCRIPTION
## Summary

This PR updates the explore page to show usernames instead of addresses, when available.





