### PR TITLE
refactor(gh-sync): Send repo Id over api call

### DIFF
--- a/src/stores/repository-core/index.ts
+++ b/src/stores/repository-core/index.ts
@@ -271,7 +271,10 @@ const createRepoCoreSlice: StateCreator<CombinedSlices, [['zustand/immer', never
             'X-GitHub-Api-Version': '2022-11-28',
             Authorization: `Bearer ${accessToken}`
           },
-          body: JSON.stringify({ ref: githubSync?.branch, inputs: { forcePush: forcePush.toString() } })
+          body: JSON.stringify({
+            ref: githubSync?.branch,
+            inputs: { forcePush: forcePush.toString(), repoId: repo.id }
+          })
         }
       )
 


### PR DESCRIPTION
## Summary

This PR modifies the GitHub Sync Workflow trigger by including the repository ID (repoId) in the inputs. This improvement eliminates the need for manual configuration of the `PL_REPO_ID` within the workflow.

Related:
https://github.com/labscommunity/protocol-land-sync-github/pull/6
https://github.com/labscommunity/protocol-land-remote-helper/pull/25