### PR TITLE
fix: Add rehype plugin for markdown headers scroll

### DIFF
--- a/src/components/IssuePr/Comment.tsx
+++ b/src/components/IssuePr/Comment.tsx
@@ -6,6 +6,7 @@ import toast from 'react-hot-toast'
 import { useNavigate } from 'react-router-dom'
 
 import { Button } from '@/components/common/buttons'
+import rehypeAnchorOnClick from '@/helpers/rehypeAnchorOnClickPlugin'
 import { resolveUsernameOrShorten } from '@/helpers/resolveUsername'
 import { useGlobalStore } from '@/stores/globalStore'
 import { Issue, IssueActivityComment, PullRequest, PullRequestActivityComment } from '@/types/repository'
@@ -143,8 +144,9 @@ export default function Comment({ isIssue, issueOrPRId, commentId, item, canEdit
           </div>
         ) : (
           <MDEditor.Markdown
-            className="p-2"
+            className="p-4"
             source={item?.description || '<i style="color: #656D76;">No description provided.</i>'}
+            rehypePlugins={[[rehypeAnchorOnClick]]}
           />
         )}
       </div>

--- a/src/helpers/rehypeAnchorOnClickPlugin.ts
+++ b/src/helpers/rehypeAnchorOnClickPlugin.ts
@@ -1,0 +1,36 @@
+import { Element } from 'hast'
+import { visit } from 'unist-util-visit'
+
+// Define a type for the properties that may be on an Element node
+interface ElementProperties {
+  href?: string
+  onClick?: (e: MouseEvent) => void
+}
+
+export const onNode = (node: Element) => {
+  // Ensure that the node is an anchor ('a') element with a href property that is a string
+  if (node.tagName !== 'a' || typeof (node.properties as ElementProperties)?.href !== 'string') return
+
+  // Since we've narrowed the type of node.properties, we can assert its type here
+  const properties = node.properties as ElementProperties
+  const url = properties.href
+
+  // Skip processing for non-anchor links
+  if (!url || !url.startsWith('#')) return
+
+  node.properties = { ...node.properties, href: 'javascript:void(0)' }
+
+  const element = document.querySelector(url)?.children?.[0]
+  if (!element) return
+  ;(element as any).onclick = (e: MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    // @ts-ignore
+    element.style.scrollMargin = '60px'
+    element.scrollIntoView({ behavior: 'smooth' })
+  }
+}
+
+export default function rehypeAnchorOnClick() {
+  return (tree: any) => visit(tree, 'element', onNode)
+}

--- a/src/pages/repository/components/tabs/code-tab/FileView.tsx
+++ b/src/pages/repository/components/tabs/code-tab/FileView.tsx
@@ -13,6 +13,7 @@ import { MdOutlineEdit } from 'react-icons/md'
 import Sticky from 'react-stickynode'
 
 import { Button } from '@/components/common/buttons'
+import rehypeAnchorOnClick from '@/helpers/rehypeAnchorOnClickPlugin'
 import { isImage, isMarkdown } from '@/pages/repository/helpers/filenameHelper'
 import useLanguage from '@/pages/repository/hooks/useLanguage'
 import { useGlobalStore } from '@/stores/globalStore'
@@ -176,7 +177,11 @@ export default function FileView({ fileContent, setFileContent, filename, setFil
                 />
               </CodeMirrorMerge>
             ) : (
-              <MDEditor.Markdown className="p-8 !min-h-[200px] rounded-b-lg" source={fileContent.modified} />
+              <MDEditor.Markdown
+                className="p-8 !min-h-[200px] rounded-b-lg"
+                source={fileContent.modified}
+                rehypePlugins={[[rehypeAnchorOnClick]]}
+              />
             )
           ) : !isMarkdownFile ? (
             <CodeMirror
@@ -201,7 +206,11 @@ export default function FileView({ fileContent, setFileContent, filename, setFil
               onChange={(value) => setFileContent((content) => ({ ...content, modified: value! }))}
             />
           ) : (
-            <MDEditor.Markdown className="p-8 !min-h-[200px] rounded-b-lg" source={fileContent.modified} />
+            <MDEditor.Markdown
+              className="p-8 !min-h-[200px] rounded-b-lg"
+              source={fileContent.modified}
+              rehypePlugins={[[rehypeAnchorOnClick]]}
+            />
           )}
         </div>
       </div>

--- a/src/pages/repository/components/tabs/code-tab/Readme.tsx
+++ b/src/pages/repository/components/tabs/code-tab/Readme.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react'
 import { LiaReadme } from 'react-icons/lia'
 import Sticky from 'react-stickynode'
 
+import rehypeAnchorOnClickPlugin from '@/helpers/rehypeAnchorOnClickPlugin'
 import { getFileContent } from '@/pages/repository/helpers/filenameHelper'
 import { useGlobalStore } from '@/stores/globalStore'
 import { FileObject } from '@/stores/repository-core/types'
@@ -54,7 +55,11 @@ export default function Readme({ fileObject }: { fileObject?: FileObject }) {
           <div className="font-medium">README</div>
         </div>
       </Sticky>
-      <MDEditor.Markdown className="p-8 !min-h-[200px] rounded-b-lg" source={isLoading ? 'Loading...' : fileContent} />
+      <MDEditor.Markdown
+        className="p-8 !min-h-[200px] rounded-b-lg"
+        source={isLoading ? 'Loading...' : fileContent}
+        rehypePlugins={[[rehypeAnchorOnClickPlugin]]}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

As we are using react hash routing, there is issues with md editor header links click. Currently, on clicking the header links it goes to a different route. This PR prevents going to a different route on clicking header links and also adds a scroll to the header on click.

## How to Test
1. Open [this PR deployed link](https://protocol-land-git-fix-md-headers-scroll-community-labs.vercel.app/#/repository/33fdc1fa-755e-4872-86a5-06607c55446b) and also [PL prod link](https://protocol.land/#/repository/33fdc1fa-755e-4872-86a5-06607c55446b).
2. Click on a header link of the Readme on both (See if this PR prevents going to the hash route).
3. Scroll down and click on a header link to see if it auto scrolls.