### PR TITLE
fix: Format ArNS balance & fees with decimals for display

### DIFF
--- a/src/components/DragonDeploy/ArNSRegister.tsx
+++ b/src/components/DragonDeploy/ArNSRegister.tsx
@@ -7,7 +7,14 @@ import * as yup from 'yup'
 
 import { Button } from '@/components/common/buttons'
 import { withAsync } from '@/helpers/withAsync'
-import { getARBalance, getArNSNameFees, getIOBalance, registerArNSName, searchArNSName } from '@/lib/dragondeploy/arns'
+import {
+  formatIOBalance,
+  getARBalance,
+  getArNSNameFees,
+  getIOBalance,
+  registerArNSName,
+  searchArNSName
+} from '@/lib/dragondeploy/arns'
 import { useGlobalStore } from '@/stores/globalStore'
 
 const schema = yup
@@ -143,11 +150,11 @@ export default function ArNSRegister({ closeModal }: ArNSRegisterProps) {
               <h3 className="font-semibold">$IO Test</h3>
               <div className="mt-2">
                 <div className="text-gray-600">Balance</div>
-                <div>{balance.io}</div>
+                <div>{formatIOBalance(balance.io)}</div>
               </div>
               <div className="mt-2">
                 <div className="text-gray-600">Fee</div>
-                <div>{fees.io}</div>
+                <div>{formatIOBalance(fees.io)}</div>
               </div>
             </div>
             <div className="text-right">

--- a/src/lib/dragondeploy/arns.ts
+++ b/src/lib/dragondeploy/arns.ts
@@ -10,6 +10,7 @@ const warp = WarpFactory.forMainnet(defaultCacheOptions, true).use(new DeployPlu
 
 const REGISTRY = 'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U'
 const ANT_SOURCE = 'H2uxnw_oVIEzXeBeYmxDgJuxPqwBCGPO4OmQzdWQu3U'
+const IO_DECIMALS = 6
 
 const arweave = new Arweave({
   host: 'ar-io.net',
@@ -111,6 +112,10 @@ export async function updateArNSDomain({
   )
 
   return { success: true, id: result.originalTxId, message: 'Successfully updated domain' }
+}
+
+export function formatIOBalance(balance: number) {
+  return (balance / Math.pow(10, IO_DECIMALS)).toFixed(3)
 }
 
 export async function getIOBalance(owner: string) {


### PR DESCRIPTION
## Summary

The PR fixes the displayed IO test balance and fees. 

**Reason for this Issue:** Maybe the ArNS api have changed on how the balance & fees are returned.

**Before this PR:**
![image](https://github.com/labscommunity/protocol-land/assets/11836100/3e6ef621-e0dc-4eba-9546-323adc863e9a)

**After this PR:**
![image](https://github.com/labscommunity/protocol-land/assets/11836100/63a610f7-ac5d-4cd6-88e7-c0cdedb135a9)

**ArNS.app:**
![image](https://github.com/labscommunity/protocol-land/assets/11836100/67762cdc-b769-4996-987f-c413a602500c)