### PR TITLE
fix: create N forks

### DIFF
--- a/src/helpers/aoconnect/index.ts
+++ b/src/helpers/aoconnect/index.ts
@@ -1,7 +1,8 @@
 import { connect, createDataItemSigner } from '@permaweb/aoconnect'
 
 const { result, results, message, spawn, monitor, unmonitor, dryrun } = connect({
-  GATEWAY_URL: 'https://arweave.net',
+  GATEWAY_URL: 'https://arweave-search.goldsky.com',
+  GRAPHQL_URL: 'https://arweave-search.goldsky.com/graphql',
   CU_URL: 'https://cu.ardrive.io'
 })
 

--- a/src/lib/bark/index.ts
+++ b/src/lib/bark/index.ts
@@ -1,5 +1,4 @@
-import { dryrun } from '@permaweb/aoconnect'
-
+import { dryrun } from '@/helpers/aoconnect'
 import { getTags } from '@/helpers/getTags'
 import { isArweaveAddress } from '@/helpers/isInvalidInput'
 import { CreateLiquidityPoolProps } from '@/pages/repository/components/decentralize-modals/config'
@@ -38,14 +37,14 @@ export async function checkLiquidityPoolReserves(poolId: string) {
     process: poolId
   }
 
-  let attempts = 0;
+  let attempts = 0
   while (attempts < 10) {
     const { Messages } = await dryrun(args)
 
     if (!Messages[0]) {
-      attempts++;
-      await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for 1 second before retrying
-      continue;
+      attempts++
+      await new Promise((resolve) => setTimeout(resolve, 1000)) // Wait for 1 second before retrying
+      continue
     }
 
     let data: Record<string, string> = {}
@@ -58,14 +57,14 @@ export async function checkLiquidityPoolReserves(poolId: string) {
     }, {})
 
     if (Object.keys(data).length >= 2) {
-      return data;
+      return data
     }
 
-    attempts++;
-    await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for 1 second before retrying
+    attempts++
+    await new Promise((resolve) => setTimeout(resolve, 1000)) // Wait for 1 second before retrying
   }
 
-  return null; // Return null if we couldn't get at least two entries after 10 attempts
+  return null // Return null if we couldn't get at least two entries after 10 attempts
 }
 
 export async function depositToLiquidityPool(poolId: string, token: RepoLiquidityPoolToken, amount: string) {

--- a/src/lib/bonding-curve/helpers.ts
+++ b/src/lib/bonding-curve/helpers.ts
@@ -1,5 +1,4 @@
-import { dryrun } from '@permaweb/aoconnect'
-
+import { dryrun } from '@/helpers/aoconnect'
 import { getTags } from '@/helpers/getTags'
 import { CurveState } from '@/stores/repository-core/types'
 

--- a/src/lib/decentralize/index.ts
+++ b/src/lib/decentralize/index.ts
@@ -1,7 +1,7 @@
-import { createDataItemSigner, dryrun, spawn } from '@permaweb/aoconnect'
 import Arweave from 'arweave'
 import { Tag } from 'arweave/web/lib/transaction'
 
+import { createDataItemSigner, dryrun, spawn } from '@/helpers/aoconnect'
 import { getTags } from '@/helpers/getTags'
 import { waitFor } from '@/helpers/waitFor'
 import { getSigner } from '@/helpers/wallet/getSigner'
@@ -13,7 +13,7 @@ import { sendMessage } from '../contract'
 import { generateSteps } from '../discrete-bonding-curve/curve'
 
 const arweave = new Arweave({
-  host: 'arweave.net',
+  host: 'arweave-search.goldsky.com',
   port: 443,
   protocol: 'https'
 })
@@ -57,8 +57,6 @@ export async function spawnTokenProcess(tokenName: string, processType?: string)
     data: '1984',
     signer: createDataItemSigner(signer)
   })
-
-  await pollForTxBeingAvailable({ txId: pid })
 
   return pid
 }

--- a/src/stores/organization/actions/index.ts
+++ b/src/stores/organization/actions/index.ts
@@ -1,6 +1,6 @@
-import { dryrun, result } from '@permaweb/aoconnect'
 import { Tag } from 'arweave/web/lib/transaction'
 
+import { dryrun, result } from '@/helpers/aoconnect'
 import { AOS_PROCESS_ID } from '@/helpers/constants'
 import { getTags } from '@/helpers/getTags'
 import { sendMessage } from '@/lib/contract'

--- a/src/stores/repository-core/actions/repoMeta.ts
+++ b/src/stores/repository-core/actions/repoMeta.ts
@@ -1,6 +1,6 @@
-import { dryrun, result } from '@permaweb/aoconnect'
 import { Tag } from 'arweave/web/lib/transaction'
 
+import { dryrun, result } from '@/helpers/aoconnect'
 import { AOS_PROCESS_ID } from '@/helpers/constants'
 import { getTags } from '@/helpers/getTags'
 import { getRepo, sendMessage } from '@/lib/contract'

--- a/src/stores/repository-core/types.ts
+++ b/src/stores/repository-core/types.ts
@@ -1,6 +1,7 @@
 import { Edge, Node } from '@xyflow/react'
 
 import { CurveStep } from '@/lib/discrete-bonding-curve/curve'
+import { FSType } from '@/lib/git/helpers/fsWithName'
 import { UserCommit, UserContributionData, UserPROrIssue } from '@/lib/user'
 import { CommitResult } from '@/types/commit'
 import { Organization } from '@/types/orgs'
@@ -128,8 +129,10 @@ export type ForkRepositoryOptions = {
   name: string
   description: string
   parent: string
-  dataTxId: string
+  fs: FSType
+  dir: string
   tokenProcessId: string
+  creator: string
 }
 
 export type SaveRepoTokenDetailsOptions = RepoToken & BondingCurve


### PR DESCRIPTION
## Summary
This PR adds fix to forking logic where parent data ref is copied to new fork and is not updated until new fork makes their first commit. During this state if new fork is further forked, 2nd fork is pointing to parent repo data ref, causing out of order issue. To simply get around this issue, forking will now upload another copy of same repo giving unique data ref to the fork. 